### PR TITLE
Get API key from env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,9 @@ RUN sed -i -e"s/^.*non_local_traffic:.*$/non_local_traffic: yes/" /etc/dd-agent/
 # Turn off syslog
 RUN sed -i -e"s/^.*log_to_syslog:.*$/log_to_syslog: no/" /etc/dd-agent/datadog.conf
 
+ADD bin/agent.sh /usr/local/bin/agent.sh
+
 # Expose DogStatsD port
 EXPOSE 8125/udp
 
-CMD ["/usr/bin/supervisord", "-n", "-c", "/etc/dd-agent/supervisor.conf"]
+CMD [ "/usr/local/bin/agent.sh" ]

--- a/bin/agent.sh
+++ b/bin/agent.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+sed -i -e "s/^.*api_key:.*$/api_key: ${DATADOG_API_KEY:?"must be set"}/" /etc/dd-agent/datadog.conf
+exec /usr/bin/supervisord -n -c /etc/dd-agent/supervisor.conf


### PR DESCRIPTION
- Supports passing in the env `DATADOG_API_KEY` instead of building your own container
- PR does not cover changes to the `README` - quickstart would presumable be one line only, using the trusted build
