### PR TITLE
Add support for network metrics

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV AGENT_VERSION 1:5.3.0-1
 RUN echo "deb http://apt.datadoghq.com/ stable main" > /etc/apt/sources.list.d/datadog.list \
  && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C7A7DA52 \
  && apt-get update \
- && apt-get install --no-install-recommends -y datadog-agent="${AGENT_VERSION}" \
+ && apt-get install --no-install-recommends -y net-tools datadog-agent="${AGENT_VERSION}" \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
@@ -19,17 +19,18 @@ RUN echo "deb http://apt.datadoghq.com/ stable main" > /etc/apt/sources.list.d/d
 # 3. Remove dd-agent user from supervisor configuration
 # 4. Remove dd-agent user from init.d configuration
 # 5. Fix permission on /etc/init.d/datadog-agent
-# 6. Remove network check
 RUN mv /etc/dd-agent/datadog.conf.example /etc/dd-agent/datadog.conf \
  && sed -i -e"s/^.*non_local_traffic:.*$/non_local_traffic: yes/" /etc/dd-agent/datadog.conf \
  && sed -i -e"s/^.*log_to_syslog:.*$/log_to_syslog: no/" /etc/dd-agent/datadog.conf \
  && sed -i "/user=dd-agent/d" /etc/dd-agent/supervisor.conf \
  && sed -i 's/AGENTUSER="dd-agent"/AGENTUSER="root"/g' /etc/init.d/datadog-agent \
- && chmod +x /etc/init.d/datadog-agent \
- && rm /etc/dd-agent/conf.d/network.yaml.default
+ && chmod +x /etc/init.d/datadog-agent
 
 # Add Docker check
 COPY conf.d/docker.yaml /etc/dd-agent/conf.d/docker.yaml
+
+# Add Network check
+COPY conf.d/network.yaml /etc/dd-agent/conf.d/network.yaml
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/README.md
+++ b/README.md
@@ -5,17 +5,16 @@ This repository is meant to build the base image for a Datadog Agent container. 
 
 ## Quick Start
 
-The default image is ready-to-go. You just need to set your hostname and API_KEY in the environment. Don't forget to set the `--privileged` flag and to mount some directories to get host metrics.
+The default image is ready-to-go. You just need to set your API_KEY in the environment. Don't forget to set the `--privileged` and `--net=host` flags and to mount some directories to get host metrics.
 
 ```
-docker run -d --name dd-agent -h `hostname` -v /var/run/docker.sock:/var/run/docker.sock -v /proc/mounts:/host/proc/mounts:ro -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro -e API_KEY={your_api_key_here} datadog/docker-dd-agent
+docker run -d --name dd-agent --net=host -v /var/run/docker.sock:/var/run/docker.sock -v /proc/mounts:/host/proc/mounts:ro -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro -e API_KEY={your_api_key_here} datadog/docker-dd-agent
 ```
 
 If you are running on Amazon Linux, use the following instead:
 
 ```
-docker run -d --name dd-agent -h hostname -v /var/run/docker.sock:/var/run/docker.sock -v /proc/mounts:/host/proc/mounts:ro -v /cgroup/:/host/sys/fs/cgroup:ro -e API_KEY={your_api_key_here}
-datadog/docker-dd-agent
+docker run -d --name dd-agent --net=host -v /var/run/docker.sock:/var/run/docker.sock -v /proc/mounts:/host/proc/mounts:ro -v /cgroup/:/host/sys/fs/cgroup:ro -e API_KEY={your_api_key_here} datadog/docker-dd-agent
 ```
 
 ## Configuration
@@ -47,7 +46,7 @@ To configure integrations or custom checks, you will need to build a Docker imag
 3. Then run it like the `datadog/docker-dd-agent` image.
 
     ```
-    docker run -d --privileged --name dd-agent -h `hostname` -v /var/run/docker.sock:/var/run/docker.sock -v /proc/mounts:/host/proc/mounts:ro -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro -e API_KEY={your_api_key_here} dd-agent-image
+    docker run -d --privileged --name dd-agent --net=host -v /var/run/docker.sock:/var/run/docker.sock -v /proc/mounts:/host/proc/mounts:ro -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro -e API_KEY={your_api_key_here} dd-agent-image
     ```
 
 4. It's done!
@@ -85,7 +84,7 @@ Basic information about the Agent execution are available through the `logs` com
 To run DogStatsD without the full Agent, add the command `dogstatsd` at the end of the `docker run` command.
 
 ```
-docker run -d --privileged --name dogstatsd -h `hostname` -v /var/run/docker.sock:/var/run/docker.sock -v /proc/mounts:/host/proc/mounts:ro -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro -e API_KEY={your_api_key_here} datadog/docker-dd-agent dogstatsd
+docker run -d --privileged --name dogstatsd --net=host -v /var/run/docker.sock:/var/run/docker.sock -v /proc/mounts:/host/proc/mounts:ro -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro -e API_KEY={your_api_key_here} datadog/docker-dd-agent dogstatsd
 ```
 
 Usage commands work, but we added simpler ones when DogStatsD is running on its own.
@@ -132,7 +131,6 @@ Docker isolates containers from the host. As a result, the Agent won't have acce
 
 Known missing/incorrect metrics:
 
-* Network
 * Process list
 
 Also, several integrations might be incomplete. See the "Contribute" section.

--- a/conf.d/network.yaml
+++ b/conf.d/network.yaml
@@ -1,0 +1,12 @@
+init_config:
+
+instances:
+  # If you want to check the number of open connections, set
+  # collect_connection_state to true
+  - collect_connection_state: false
+    excluded_interfaces:
+      - lo
+      - lo0
+      - docker0
+    # Ignore Docker's virtual interfaces:
+    excluded_interface_re: veth*

--- a/dd-agent.service
+++ b/dd-agent.service
@@ -4,20 +4,17 @@ After=docker.service
 
 [Service]
 Restart=always
-ExecStartPre=-/usr/bin/docker stop dd-agent
-ExecStartPre=-/usr/bin/docker rm -f dd-agent
-ExecStartPre=/usr/bin/docker pull datadog/docker-dd-agent
-TimeoutStartSec=0
-ExecStartPre=-/usr/bin/docker kill dd-agent
-ExecStartPre=-/usr/bin/docker rm dd-agent
+TimeoutStartSec=20m
+ExecStartPre=-/usr/bin/docker rm -f -v dd-agent
+ExecStartPre=-/usr/bin/docker pull datadog/docker-dd-agent
 ExecStart=/usr/bin/bash -c \
-"/usr/bin/docker run --privileged --name dd-agent -h `hostname` \
+"/usr/bin/docker run --privileged --name dd-agent --net=host \
 -v /var/run/docker.sock:/var/run/docker.sock \
 -v /proc/mounts:/host/proc/mounts:ro \
 -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
--e API_KEY=`etcdctl get /ddapikey` \
+-e API_KEY=`etcdctl --no-sync get /ddapikey` \
 datadog/docker-dd-agent"
-ExecStop=/usr/bin/docker stop dd-agent
+ExecStop=/usr/bin/docker kill dd-agent
 
 [X-Fleet]
 Global=true


### PR DESCRIPTION
I've made some adjustments to allow the container to collect network stats.

The main change is to switch -h `hostname` with --net=host. This gives the container access to the network interfaces of the host.
I've also cleaned up the service file, based on my experience with CoreOS.