### PR TITLE
Added 'dd_url' param to the ENV variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ A few parameters can be changed with environment variables.
 * `TAGS` set host tags. Add `-e TAGS="mytag0,mytag1"` to use [mytag0, mytag1] as host tags.
 * `LOG_LEVEL` set logging verbosity (CRITICAL, ERROR, WARNING, INFO, DEBUG). Add `-e LOG_LEVEL=DEBUG` to turn logs to debug mode.
 * `PROXY_HOST`, `PROXY_PORT`, `PROXY_USER` and `PROXY_PASSWORD` set the proxy configuration.
+* `DD_URL` set the Datadog intake server to send Agent data to (used when [using an agent as a proxy](https://github.com/DataDog/dd-agent/wiki/Proxy-Configuration#using-the-agent-as-a-proxy) )
 
 ### Build an image
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,6 +16,10 @@ if [[ $LOG_LEVEL ]]; then
     sed -i -e"s/^.*log_level:.*$/log_level: ${LOG_LEVEL}/" /etc/dd-agent/datadog.conf
 fi
 
+if [[ $DD_URL ]]; then
+  sed -i -e "s/^.*dd_url:.*$/dd_url: ${DD_URL}/" /etc/dd-agent/datadog.conf
+fi
+
 if [[ $PROXY_HOST ]]; then
     sed -i -e "s/^# proxy_host:.*$/proxy_host: ${PROXY_HOST}/" /etc/dd-agent/datadog.conf
 fi


### PR DESCRIPTION
I've Added the `dd_url` param to the ENV variables. 

That way we can set it to use an other agent as a proxy ([DOC](https://github.com/DataDog/dd-agent/wiki/Proxy-Configuration#using-the-agent-as-a-proxy))

I did also updated the `Readme.md` according to the change, feel free to update the text to make it more clear.