### PR TITLE
Add support for adding yaml files in conf.d without rebuilding a Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,10 @@ COPY conf.d/docker_daemon.yaml /etc/dd-agent/conf.d/docker_daemon.yaml
 
 COPY entrypoint.sh /entrypoint.sh
 
+# Extra conf.d
+CMD mkdir -p /conf.d
+VOLUME ["/conf.d"]
+
 # Expose DogStatsD port
 EXPOSE 8125/udp
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -36,6 +36,8 @@ if [[ $PROXY_PASSWORD ]]; then
     sed -i -e "s/^# proxy_password:.*$/proxy_password: ${PROXY_USER}/" /etc/dd-agent/datadog.conf
 fi
 
+find /conf.d -name '*.yaml' -exec cp {} /etc/dd-agent/conf.d \;
+
 export PATH="/opt/datadog-agent/embedded/bin:/opt/datadog-agent/bin:$PATH"
 
 exec "$@"


### PR DESCRIPTION
Hi,

This is a proof of concept, let me know what you think.

The idea is to be able to mount a volume containing some additional config instead of having to build another Docker image on top of yours.