### PR TITLE
This patch resolves #53

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ A few parameters can be changed with environment variables.
 
 ### Enabling integrations
 
-To enable integrations you can write your YAML configuration files in the `/conf.d` folder, they will automatically be copied to `/etc/dd-agent/conf.d/` when the container starts.
+To enable integrations you can write your YAML configuration files in the `/conf.d` folder, they will automatically be copied to `/etc/dd-agent/conf.d/` when the container starts.  You can also do the same for the `/checks.d` folder.   Any Python files in the `/checks.d` folder will automatically be copied to the `/etc/dd-agent/conf.d/` when the container starts.
 
-1. Create a configuration folder on the host and write your YAML files in it.
+1. Create a configuration folder on the host and write your YAML files in it.  The examples below can be used for the `/checks.d` folder as well.
 
     ```
     mkdir /opt/dd-agent-conf.d

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -38,6 +38,8 @@ fi
 
 find /conf.d -name '*.yaml' -exec cp {} /etc/dd-agent/conf.d \;
 
+find /checks.d -name '*.py' -exec cp {} /etc/dd-agent/checks.d \;
+
 export PATH="/opt/datadog-agent/embedded/bin:/opt/datadog-agent/bin:$PATH"
 
 exec "$@"


### PR DESCRIPTION
To not break anyone who is currently using /conf.d I used the same approach for /checks.d.   It would be cleaner in my opinion to have 1 directory like /opt/docker-dd-agent that get's mounted into the container at /docker-dd-agent and the entrypoint script looks for /docker-dd-agent/conf.d/*yaml and /docker-dd-agent/checks.d/*py and copies them to their proper location.

Let me know if you want me to do change it so only one mountpoint is required on the docker container.