### PR TITLE
Symlink dogstatsd in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,13 +20,15 @@ RUN echo "deb http://apt.datadoghq.com/ docker main" > /etc/apt/sources.list.d/d
 # 4. Remove dd-agent user from init.d configuration
 # 5. Fix permission on /etc/init.d/datadog-agent
 # 6. Remove network check
+# 7. Symlink Dogstatsd to allow standalone execution
 RUN mv /etc/dd-agent/datadog.conf.example /etc/dd-agent/datadog.conf \
  && sed -i -e"s/^.*non_local_traffic:.*$/non_local_traffic: yes/" /etc/dd-agent/datadog.conf \
  && sed -i -e"s/^.*log_to_syslog:.*$/log_to_syslog: no/" /etc/dd-agent/datadog.conf \
  && sed -i "/user=dd-agent/d" /etc/dd-agent/supervisor.conf \
  && sed -i 's/AGENTUSER="dd-agent"/AGENTUSER="root"/g' /etc/init.d/datadog-agent \
  && chmod +x /etc/init.d/datadog-agent \
- && rm /etc/dd-agent/conf.d/network.yaml.default
+ && rm /etc/dd-agent/conf.d/network.yaml.default \
+ && ln -s /opt/datadog-agent/agent/dogstatsd.py /usr/bin/dogstatsd
 
 # Add Docker check
 COPY conf.d/docker_daemon.yaml /etc/dd-agent/conf.d/docker_daemon.yaml


### PR DESCRIPTION
Standalone dogstatsd functionality has been broken since we moved builds to Omnibus 4 (`dogstatsd` executable was not symlinked as required). I added a symlink step in the Dockerfile and this patch is available under the `standalone-dogstatsd` tag for those who want to use it immediately. I stood up this PR in case we want to keep this functionality for future releases.

There were a couple of candidates for where to actually specify the symlink (`entrypoint.sh` v/s `Dockerfile`). In the end I specified it in the Dockerfile since that seemed the first place people would look to check what we're doing with the filesystem.