### PR TITLE
supporting env vars in yaml files under /etc/dd-agent/conf.d

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -48,14 +48,14 @@ for file in /etc/dd-agent/conf.d/*.yaml; do
  then
   # create temp file
   echo -n "" > "$file".tmp
-  while read -r line ; do
+  while IFS='' read -r line ; do
      while [[ "$line" =~ (\$\{[a-zA-Z_][a-zA-Z_0-9]*\}) ]] ; do
          LHS=${BASH_REMATCH[1]}
          RHS="$(eval echo "\"$LHS\"")"
          line=${line//$LHS/$RHS}
      done
-     # echo the processed line to the temp file
-     echo "$line" >> "$file".tmp
+     # add the processed line to the temp file
+     printf "%s\n" "$line" >> "$file".tmp
   done < "$file"
 
   # write the temp file instead of the original file

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -42,6 +42,30 @@ fi
 
 find /conf.d -name '*.yaml' -exec cp {} /etc/dd-agent/conf.d \;
 
+# replacing env var templates with env var values, for instance: ${SHELL} with /bin/bash
+for file in /etc/dd-agent/conf.d/*.yaml; do
+ if [ -f "$file" ]
+ then
+  # create temp file
+  echo -n "" > "$file".tmp
+  while read -r line ; do
+     while [[ "$line" =~ (\$\{[a-zA-Z_][a-zA-Z_0-9]*\}) ]] ; do
+         LHS=${BASH_REMATCH[1]}
+         RHS="$(eval echo "\"$LHS\"")"
+         line=${line//$LHS/$RHS}
+     done
+     # echo the processed line to the temp file
+     echo "$line" >> "$file".tmp
+  done < "$file"
+
+  # write the temp file instead of the original file
+  cat "$file".tmp > "$file"
+  # delete the temp file
+  rm "$file".tmp
+ fi
+done
+
+
 find /checks.d -name '*.py' -exec cp {} /etc/dd-agent/checks.d \;
 
 export PATH="/opt/datadog-agent/embedded/bin:/opt/datadog-agent/bin:$PATH"


### PR DESCRIPTION
Hi,

A code to run over all of the yaml conf files and replace any env var with it related value.
I actually copy paste most of the code but I tested it locally and it looks fine.

There is also the option to use `envsubst`, but it was not installed on the image, so I choose to implement it with regex.

Thanks,
Shay