### PR TITLE
ensure docker is running when trying to run the datadog service

### DIFF
--- a/dd-agent.service
+++ b/dd-agent.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Datadog Agent
+Requires=docker.service
 After=docker.service
 
 [Service]


### PR DESCRIPTION
In systemd the `After` directive will only ensure execution ordering of
the specified units if they happen to be started at the same time, but
it does not specify a dependency relation.

`Requires=docker.service` will make sure docker is up and running before
attempting to run the commands of this service.

Signed-off-by: Petros Angelatos <petrosagg@gmail.com>