### PR TITLE
Remove unused CMD lines from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,8 +36,6 @@ COPY conf.d/docker_daemon.yaml /etc/dd-agent/conf.d/docker_daemon.yaml
 COPY entrypoint.sh /entrypoint.sh
 
 # Extra conf.d and checks.d
-CMD mkdir -p /conf.d
-CMD mkdir -p /checks.d
 VOLUME ["/conf.d"]
 VOLUME ["/checks.d"]
 


### PR DESCRIPTION
I noticed two unused lines in your Dockerfile. They're both being overridden by the last `CMD` line in the file. In this case, I'd bet the author meant to use `RUN` instead.
```Dockerfile
...
CMD mkdir -p /conf.d
CMD mkdir -p /checks.d
...
CMD ["supervisord", "-n", "-c", "/etc/dd-agent/supervisor.conf"]
```


See the following excerpt from the [Docker Docs](https://docs.docker.com/engine/reference/builder/#cmd):
>Note: don’t confuse `RUN` with `CMD`. `RUN` actually runs a command and commits the result; `CMD` does not execute anything at build time, but specifies the intended command for the image. 

And since you're using `VOLUME` on the next line, those actually create the directory if needed. If you weren't using volumes, these lines would need to be changed to `RUN`, but since you are, they're [_NOP_](https://en.wikipedia.org/wiki/NOP) anyway.