### PR TITLE
Configurable datadog.conf hostname

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,6 +8,10 @@ else
 	exit 1
 fi
 
+if [[ $AGENT_HOSTNAME ]]; then
+	sed -i -e "s/^#hostname:.*$/hostname: ${AGENT_HOSTNAME}/" /etc/dd-agent/datadog.conf
+fi
+
 if [[ $TAGS ]]; then
 	sed -i -e "s/^#tags:.*$/tags: ${TAGS}/" /etc/dd-agent/datadog.conf
 fi


### PR DESCRIPTION
We'd like to be able to set the hostname in datadog.conf. Even when passing the fqdn in via `docker run -h` the agent was still only using the machine name as the hostname in the infrastructure list and not the entire fqdn. We've had some other minor hostname issues, so we prefer being able to set this explicitly in some cases.

Thanks!