### PR TITLE
Namespace ENV vars.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 #set -e
 
+if [[ $DD_API_KEY ]]; then
+  export API_KEY=${DD_API_KEY}
+fi
+
 if [[ $API_KEY ]]; then
 	sed -i -e "s/^.*api_key:.*$/api_key: ${API_KEY}/" /etc/dd-agent/datadog.conf
 else
@@ -8,8 +12,16 @@ else
 	exit 1
 fi
 
+if [[ $DD_TAGS ]]; then
+  export TAGS=${DD_TAGS}
+fi
+
 if [[ $TAGS ]]; then
 	sed -i -e "s/^#tags:.*$/tags: ${TAGS}/" /etc/dd-agent/datadog.conf
+fi
+
+if [[ $DD_LOG_LEVEL ]]; then
+  export LOG_LEVEL=$DD_LOG_LEVEL
 fi
 
 if [[ $LOG_LEVEL ]]; then


### PR DESCRIPTION
We want to use the datadog image in elasticbeanstalk environments.  When used in this method, environment variables are set globally for all containers.  Using an environment variable name of `API_KEY` could cause some serious clashes with other containers.

By allowing for alternate environment variables `DD_API_KEY`, `DD_TAGS` and `DD_LOG_LEVEL` this ensures that we don't end up with any conflicts.  The original ENV vars still work and exist, so this should not break backwards compatibility.