### PR TITLE
Update kubernetes.yaml

### DIFF
--- a/conf.d/kubernetes.yaml
+++ b/conf.d/kubernetes.yaml
@@ -20,7 +20,7 @@ instances:
   # to keep them unique.
   # When true, we aggregate data based on container image.
   #
-   use_histogram: True
+  # use_histogram: True
   #
   # kubelet_port: 10255
   #

--- a/conf.d/kubernetes.yaml
+++ b/conf.d/kubernetes.yaml
@@ -1,18 +1,33 @@
 init_config:
-  # How to connect to cAdvisor
+  #    tags:
+  #      - optional_tag1
+  #      - optional_tag2
+
+instances:
+  # The kubernetes check retrieves metrics from cadvisor running under kubelet.
+  # By default we will assume we're running under docker and will use the address
+  # of the default router to reach the cadvisor api.
+  # 
+  # To override, e.g. in the case of a standalone cadvisor instance, use the following:
+  #
   # host: localhost
   # port: 4194 
   # method: http
+ - port: 4194
+
+  # use_histogram controls whether we send detailed metrics, i.e. one per container. 
+  # When false, we send detailed metrics corresponding to individual containers, tagging by container id
+  # to keep them unique.
+  # When true, we aggregate data based on container image.
   #
-  # Getting the master checks
-  # master_host: localhost
-  # master_port: 8080
+   use_histogram: True
   #
-  # Kubelet checks
-  # enable_kubelet_checks: true
   # kubelet_port: 10255
   #
-  # Do you want container names as tags?
-  # publish_container_names: false
-
-instances: [{"foo": "bar"}]
+  # We can define a whitelist of patterns that permit publishing raw metrics.
+  # enabled_rates:
+  #   - cpu.*
+  #   - network.*
+  #
+  # enabled_gauges:
+  #   - filesystem.*


### PR DESCRIPTION
## WHY

https://github.com/DataDog/docker-dd-agent/blob/kubernetes/conf.d/kubernetes.yaml

There is some old option in comment.
no longer used `# enable_kubelet_checks: true`

Please update to https://github.com/DataDog/dd-agent/blob/master/conf.d/kubernetes.yaml.example 🙇 

## WHAT

Update kubernetes.yaml for https://github.com/DataDog/dd-agent/pull/2512

cf. https://github.com/DataDog/dd-agent/blob/master/conf.d/kubernetes.yaml.example