### PR TITLE
Deprecation warning for DOGSTATSD_ONLY

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,15 +20,13 @@ RUN echo "deb http://apt.datadoghq.com/ stable main" > /etc/apt/sources.list.d/d
 # 4. Remove dd-agent user from init.d configuration
 # 5. Fix permission on /etc/init.d/datadog-agent
 # 6. Remove network check
-# 7. Symlink Dogstatsd to allow standalone execution
 RUN mv /etc/dd-agent/datadog.conf.example /etc/dd-agent/datadog.conf \
  && sed -i -e"s/^.*non_local_traffic:.*$/non_local_traffic: yes/" /etc/dd-agent/datadog.conf \
  && sed -i -e"s/^.*log_to_syslog:.*$/log_to_syslog: no/" /etc/dd-agent/datadog.conf \
  && sed -i "/user=dd-agent/d" /etc/dd-agent/supervisor.conf \
  && sed -i 's/AGENTUSER="dd-agent"/AGENTUSER="root"/g' /etc/init.d/datadog-agent \
  && chmod +x /etc/init.d/datadog-agent \
- && rm /etc/dd-agent/conf.d/network.yaml.default \
- && ln -s /opt/datadog-agent/agent/dogstatsd.py /usr/bin/dogstatsd
+ && rm /etc/dd-agent/conf.d/network.yaml.default
 
 # Add Docker check
 COPY conf.d/docker_daemon.yaml /etc/dd-agent/conf.d/docker_daemon.yaml

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -83,6 +83,7 @@ find /checks.d -name '*.py' -exec cp {} /etc/dd-agent/checks.d \;
 export PATH="/opt/datadog-agent/embedded/bin:/opt/datadog-agent/bin:$PATH"
 
 if [[ $DOGSTATSD_ONLY ]]; then
+        echo "[WARNING] This option is deprecated as of agent 5.8.0, it will be removed in the next few versions. Please use the dogstatsd image instead."
 		PYTHONPATH=/opt/datadog-agent/agent /opt/datadog-agent/embedded/bin/python /opt/datadog-agent/agent/dogstatsd.py
 else
 		exec "$@"


### PR DESCRIPTION
# Why

This PR is the first step towards providing a separate image to run a standalone dogstatsd server. 
The goal being to allow users to run a dogstatsd server container as a non-root user, and avoid mounting `/proc`, `/sys` and the docker socket just for running dogstatsd

# Related
- #79 
- #97