### PR TITLE
Add dogstatsd image definition in dogstatsd folder

### DIFF
--- a/dogstatsd/Dockerfile
+++ b/dogstatsd/Dockerfile
@@ -1,0 +1,40 @@
+FROM debian:jessie
+
+MAINTAINER Datadog <package@datadoghq.com>
+
+ENV DOCKER_DD_AGENT=yes \
+    AGENT_VERSION=1:5.8.5-1
+
+COPY entrypoint.sh supervisor.conf /
+
+# Install the Agent
+RUN echo "deb http://apt.datadoghq.com/ stable main" > /etc/apt/sources.list.d/datadog.list \
+ && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C7A7DA52 \
+ && apt-get update \
+ && apt-get install --no-install-recommends -y datadog-agent="${AGENT_VERSION}" \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Configure the Agent
+# 1. Listen to statsd from other containers
+# 2. Turn syslog off
+# 3. Use custom supervisor.conf
+RUN mv /etc/dd-agent/datadog.conf.example /etc/dd-agent/datadog.conf \
+ && sed -i -e"s/^.*non_local_traffic:.*$/non_local_traffic: yes/" /etc/dd-agent/datadog.conf \
+ && sed -i -e"s/^.*log_to_syslog:.*$/log_to_syslog: no/" /etc/dd-agent/datadog.conf \
+ && mv /supervisor.conf /etc/dd-agent/supervisor.conf
+
+# Expose supervisor and DogStatsD port
+EXPOSE 9001/tcp 8125/udp
+
+# Set proper permissions to allow running as a non-root user
+RUN chmod g+w /etc/dd-agent/datadog.conf \
+ && chmod -R g+w /var/log/datadog \
+ && chmod g+w /etc/dd-agent \
+ && chmod g+w /opt/datadog-agent/run/
+
+ENTRYPOINT ["/entrypoint.sh"]
+
+USER 1001
+
+CMD ["supervisord", "-n", "-c", "/etc/dd-agent/supervisor.conf"]

--- a/dogstatsd/README.md
+++ b/dogstatsd/README.md
@@ -1,0 +1,29 @@
+# DogStatsD Dockerfile
+
+This repository is meant to build the image for a DogStatsD container.
+
+## Quick Start
+
+This image is ready-to-go, you just need to set your hostname and `API_KEY` in the environment.
+
+```
+docker run -d --name dogstatsd -h `hostname` -e API_KEY=YOUR_API_KEY datadog/docker-dogstatsd
+```
+
+## Link to other containers
+
+Your other containers will probably want to send data to the DogStatsD container. For that, you will need to add a `--link` option to your run command.
+
+```
+docker run  --name my_container \
+            --all_your_flags \
+            --link dogstatsd:dogstatsd \
+            my_image_id
+```
+
+Then you will have DogStatsd address and port accessible from your environment in `DOGSTATSD_PORT_8125_UDP_ADDR` and `DOGSTATSD_PORT_8125_UDP_PORT`.
+
+
+## Administration
+
+You can refer to [docker-dd-agent documentation](https://github.com/DataDog/docker-dd-agent/).

--- a/dogstatsd/alpine/Dockerfile
+++ b/dogstatsd/alpine/Dockerfile
@@ -1,0 +1,47 @@
+FROM alpine:3.4
+
+MAINTAINER Datadog <package@datadoghq.com>
+
+ENV DD_HOME=/opt/datadog-agent \
+    DOCKER_DD_AGENT=yes \
+    AGENT_VERSION=5.8.5 \
+    # prevent the agent from being started after install
+    DD_START_AGENT=0
+
+# Add install and config files
+ADD https://raw.githubusercontent.com/DataDog/dd-agent/$AGENT_VERSION/packaging/datadog-agent/source/setup_agent.sh /tmp/setup_agent.sh
+COPY entrypoint.sh supervisor.conf /
+
+# Expose supervisor and DogStatsD port
+EXPOSE 9001/tcp 8125/udp
+
+# Install minimal dependencies
+RUN apk add -qU --no-cache curl-dev python-dev tar sysstat
+
+# Install build dependencies
+RUN apk add -qU --no-cache -t .build-deps curl gcc musl-dev pgcluster-dev linux-headers \
+    # Install the agent
+    && sh /tmp/setup_agent.sh \
+    # Clean build dependencies
+    && apk del -q .build-deps
+
+# Configure the Agent
+# 1. Listen to statsd from other containers
+# 2. Turn syslog off
+# 3. Use custom supervisor.conf
+# 4. Clean up the install script
+RUN mv $DD_HOME/agent/datadog.conf.example $DD_HOME/agent/datadog.conf \
+ && sed -i -e"s/^.*non_local_traffic:.*$/non_local_traffic: yes/" $DD_HOME/agent/datadog.conf \
+ && sed -i -e"s/^.*log_to_syslog:.*$/log_to_syslog: no/" $DD_HOME/agent/datadog.conf \
+ && mv /supervisor.conf $DD_HOME/agent/supervisor.conf \
+ && rm /tmp/setup_agent.sh
+
+# Set proper permissions to allow running as a non-root user
+RUN chmod -R g+wx $DD_HOME \
+  && chmod g+x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+
+USER 1001
+
+CMD supervisord -n -c $DD_HOME/agent/supervisor.conf

--- a/dogstatsd/alpine/entrypoint.sh
+++ b/dogstatsd/alpine/entrypoint.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+#set -e
+
+if [[ $DD_API_KEY ]]; then
+  export API_KEY=${DD_API_KEY}
+fi
+
+if [[ $API_KEY ]]; then
+    sed -i -e "s/^.*api_key:.*$/api_key: ${API_KEY}/" $DD_HOME/agent/datadog.conf
+else
+    echo "You must set API_KEY environment variable to run the DogStatsD container"
+    exit 1
+fi
+
+if [[ $DD_URL ]]; then
+    sed -i -e 's@^.*dd_url:.*$@dd_url: '${DD_URL}'@' $DD_HOME/agent/datadog.conf
+fi
+
+export PATH="$DD_HOME/venv/bin:$DD_HOME/bin:$PATH"
+
+exec "$@"

--- a/dogstatsd/alpine/supervisor.conf
+++ b/dogstatsd/alpine/supervisor.conf
@@ -1,0 +1,39 @@
+[supervisorctl]
+serverurl = unix:///opt/datadog-agent/run/datadog-supervisor.sock
+
+[unix_http_server]
+file=/opt/datadog-agent/run/datadog-supervisor.sock
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisord]
+http_port = /opt/datadog-agent/run/datadog-supervisor.sock
+minfds = 1024
+minprocs = 200
+loglevel = info
+logfile = /opt/datadog-agent/logs/supervisord.log
+logfile_maxbytes = 50MB
+nodaemon = false
+pidfile = /opt/datadog-agent/run/datadog-supervisord.pid
+logfile_backups = 10
+environment=PYTHONPATH=/opt/datadog-agent/agent,LANG=POSIX
+
+[program:forwarder]
+command=/opt/datadog-agent/venv/bin/python /opt/datadog-agent/agent/ddagent.py
+stdout_logfile=NONE
+stderr_logfile=NONE
+startsecs=5
+startretries=3
+priority=998
+
+[program:dogstatsd]
+command=/opt/datadog-agent/venv/bin/python /opt/datadog-agent/agent/dogstatsd.py --use-local-forwarder
+stdout_logfile=NONE
+stderr_logfile=NONE
+startsecs=5
+startretries=3
+priority=998
+
+[group:datadog-agent]
+programs=forwarder,dogstatsd

--- a/dogstatsd/entrypoint.sh
+++ b/dogstatsd/entrypoint.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#set -e
+
+if [[ $DD_API_KEY ]]; then
+  export API_KEY=${DD_API_KEY}
+fi
+
+if [[ $API_KEY ]]; then
+	sed -i -e "s/^.*api_key:.*$/api_key: ${API_KEY}/" /etc/dd-agent/datadog.conf
+else
+	echo "You must set API_KEY environment variable to run the DogStatsD container"
+	exit 1
+fi
+
+if [[ $DD_URL ]]; then
+    sed -i -e 's@^.*dd_url:.*$@dd_url: '${DD_URL}'@' /etc/dd-agent/datadog.conf
+fi
+
+export PATH="/opt/datadog-agent/embedded/bin:/opt/datadog-agent/bin:$PATH"
+
+exec "$@"

--- a/dogstatsd/supervisor.conf
+++ b/dogstatsd/supervisor.conf
@@ -1,0 +1,39 @@
+[supervisorctl]
+serverurl = unix:///opt/datadog-agent/run/datadog-supervisor.sock
+
+[unix_http_server]
+file=/opt/datadog-agent/run/datadog-supervisor.sock
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisord]
+http_port = /opt/datadog-agent/run/datadog-supervisor.sock
+minfds = 1024
+minprocs = 200
+loglevel = info
+logfile = /var/log/datadog/supervisord.log
+logfile_maxbytes = 50MB
+nodaemon = false
+pidfile = /opt/datadog-agent/run/datadog-supervisord.pid
+logfile_backups = 10
+environment=PYTHONPATH=/opt/datadog-agent/agent,LANG=POSIX
+
+[program:forwarder]
+command=/opt/datadog-agent/embedded/bin/python /opt/datadog-agent/agent/ddagent.py
+stdout_logfile=NONE
+stderr_logfile=NONE
+startsecs=5
+startretries=3
+priority=998
+
+[program:dogstatsd]
+command=/opt/datadog-agent/embedded/bin/python /opt/datadog-agent/agent/dogstatsd.py --use-local-forwarder
+stdout_logfile=NONE
+stderr_logfile=NONE
+startsecs=5
+startretries=3
+priority=998
+
+[group:datadog-agent]
+programs=forwarder,dogstatsd


### PR DESCRIPTION
# Why

To make it possible to run a dogstatsd server container with a non-root user.

# What

This PR make it possible to build a dogstatsd only image. It is based on the (deprecated) https://github.com/DataDog/docker-dogstatsd repository with a few updates. It also runs the server as user id 1001. We don't use a username because it doesn't guarantee that the user is not modified in the dockerfile or entrypoint to effectively be root, so some platforms won't allow it to run for security reasons.

# Related issues:
- fixes https://github.com/DataDog/docker-dd-agent/issues/79