### PR TITLE
Add a DD_HOSTNAME env variable

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,6 +12,10 @@ else
 	exit 1
 fi
 
+if [[ $DD_HOSTNAME ]]; then
+	sed -i -e "s/^#hostname.*$/hostname: ${DD_HOSTNAME}/" /etc/dd-agent/datadog.conf
+fi
+
 if [[ $DD_TAGS ]]; then
   export TAGS=${DD_TAGS}
 fi


### PR DESCRIPTION
Requested often as the docker run `-h` flag isn't taken into account by dd-agent's `get_hostname` function.