### PR TITLE
dd-agent:mesos - fixes monitoring of Mesos agents

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,11 @@ MAINTAINER Datadog <package@datadoghq.com>
 ENV DOCKER_DD_AGENT yes
 ENV AGENT_VERSION 1:5.8.0-1
 
-# Install the Agent
+# Install the Agent + dnsutils
 RUN echo "deb http://apt.datadoghq.com/ stable main" > /etc/apt/sources.list.d/datadog.list \
  && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C7A7DA52 \
  && apt-get update \
- && apt-get install --no-install-recommends -y datadog-agent="${AGENT_VERSION}" \
+ && apt-get install --no-install-recommends -y datadog-agent="${AGENT_VERSION}" dnsutils \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
@@ -33,15 +33,24 @@ RUN mv /etc/dd-agent/datadog.conf.example /etc/dd-agent/datadog.conf \
 # Add Docker check
 COPY conf.d/docker_daemon.yaml /etc/dd-agent/conf.d/docker_daemon.yaml
 
-COPY entrypoint.sh /entrypoint.sh
+# Add Mesos master/slave check
+COPY conf.d/mesos_master.yaml /etc/dd-agent/conf.d/mesos_master.yaml
+COPY conf.d/mesos_slave.yaml /etc/dd-agent/conf.d/mesos_slave.yaml
+
+# Add Marathon check
+COPY conf.d/marathon.yaml /etc/dd-agent/conf.d/marathon.yaml
+
+# Add Zookeeper check
+COPY conf.d/zk.yaml /etc/dd-agent/conf.d/zk.yaml
 
 # Extra conf.d and checks.d
 VOLUME ["/conf.d"]
 VOLUME ["/checks.d"]
 
-# Expose DogStatsD port
-EXPOSE 8125/udp
+COPY entrypoint.sh /entrypoint.sh
+
+# Expose DogStatsD port and supervisord
+EXPOSE 8125/udp 9001/tcp
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["supervisord", "-n", "-c", "/etc/dd-agent/supervisor.conf"]
-

--- a/conf.d/docker_daemon.yaml
+++ b/conf.d/docker_daemon.yaml
@@ -58,6 +58,16 @@ instances:
     #
     # collect_image_size: false
 
+    # Collect disk metrics (total, used, free) through the docker info command for data and metadata.
+    # This is useful when these values can't be obtained by the disk check.
+    # Example: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html
+    # Note that it only works when the storage driver is devicemapper.
+    # Explanation of these metrics can be found here:
+    # https://github.com/docker/docker/blob/v1.11.1/daemon/graphdriver/devmapper/README.md
+    # Defaults to false.
+    #
+    # collect_disk_stats: true
+
 
     # Exclude containers based on their tags
     # An excluded container will be completely ignored. The rule is a regex on the tags.
@@ -101,6 +111,7 @@ instances:
     #   - docker_image: LEGACY. The full image name:tag string (example: "nginx:latest")
     #   - container_name: Name of the container (example: "boring_euclid")
     #   - container_command: Command ran by the container (example: "echo 1")
+    #   - container_id: Id of the container
     #
     # performance_tags: ["container_name", image_name", "image_tag", "docker_image"]
 
@@ -112,4 +123,4 @@ instances:
     # List of container label names that should be collected and sent as tags.
     # Default to None
     # Example:
-    # collect_labels_as_tags: ["com.docker.compose.service", "com.docker.compose.project"] 
+    # collect_labels_as_tags: ["com.docker.compose.service", "com.docker.compose.project"]

--- a/conf.d/marathon.yaml
+++ b/conf.d/marathon.yaml
@@ -1,0 +1,11 @@
+init_config:
+# time to wait on a Marathon API request
+  # default_timeout: 5
+
+instances:
+# url: the API endpoint of your Marathon master
+  # - url: "https://server:port"
+  #
+  #   if marathon is protected by basic auth
+  #   user: "username"
+  #   password: "password"

--- a/conf.d/mesos_master.yaml
+++ b/conf.d/mesos_master.yaml
@@ -1,0 +1,5 @@
+init_config:
+  default_timeout: 10
+
+instances:
+  - url: "http://leader.mesos:5050"

--- a/conf.d/mesos_slave.yaml
+++ b/conf.d/mesos_slave.yaml
@@ -1,0 +1,4 @@
+init_config:
+  default_timeout: 10
+
+instances:

--- a/conf.d/zk.yaml
+++ b/conf.d/zk.yaml
@@ -1,0 +1,14 @@
+init_config:
+
+instances:
+  - host: master.mesos
+    port: 2181
+    # timeout: 3
+    # tags:
+    #   - optional_tag1
+    #   - optional_tag2
+
+    # If `expected_mode` is defined we'll send a service check where the
+    # status is determined by whether the current mode matches the expected.
+    # Options: leader, follower, standalone
+    # expected_mode: leader


### PR DESCRIPTION
Dynamically fetches the list of mesos agents from mesos-dns and alters `/etc/dd-agent/conf.d/mesos_slave.yaml` accordingly.

This still under-reports the number of master nodes, but I'm not sure how to fix that.

You can try this by launching the datadog package in DC/OS and replacing the docker image in the marathon config with `bowbaq/docker-dd-agent:mesos`.