### PR TITLE
Add Mesos monitoring to default tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,9 +39,8 @@ COPY entrypoint.sh /entrypoint.sh
 VOLUME ["/conf.d"]
 VOLUME ["/checks.d"]
 
-# Expose DogStatsD port
-EXPOSE 8125/udp
+# Expose DogStatsD and supervisord ports
+EXPOSE 8125/udp 9001/tcp
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["supervisord", "-n", "-c", "/etc/dd-agent/supervisor.conf"]
-

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ By default the agent container will use the `Name` field found in the `docker in
 
 ### Environment variables
 
-A few parameters can be changed with environment variables.
+A few parameters can be changed with environment variables:
 
 * `DD_HOSTNAME` set the hostname (write it in `datadog.conf`)
 * `TAGS` set host tags. Add `-e TAGS="simple-tag-0,tag-key-1:tag-value-1"` to use [simple-tag-0, tag-key-1:tag-value-1] as host tags.
@@ -64,6 +64,10 @@ A few parameters can be changed with environment variables.
 `SD_CONFIG_BACKEND` can be set to `etcd` or `consul` which are the two configuration stores we support right now.
 `SD_BACKEND_HOST` and `SD_BACKEND_PORT` are used to configure the connection to the configuration store, and `SD_TEMPLATE_DIR` to specify the path where the check configuration templates are stored.
 
+It is also possible to enable some checks this way:
+
+* `MESOS_MASTER` and `MESOS_SLAVE` respectively enable the mesos master and mesos slave checks.
+* `MARATHON_URL` if set will be used to enable the Marathon check that will query the URL passed in this variable for metrics. It can usually be set to `http://leader.mesos:8080`.
 
 **Note:** it is possible to use `DD_TAGS` instead of `TAGS`, `DD_LOG_LEVEL` instead of `LOG_LEVEL` and `DD_API_KEY` instead of `API_KEY`, these variables have the same impact.
 

--- a/alpine/conf.d/docker_daemon.yaml
+++ b/alpine/conf.d/docker_daemon.yaml
@@ -58,6 +58,16 @@ instances:
     #
     # collect_image_size: false
 
+    # Collect disk metrics (total, used, free) through the docker info command for data and metadata.
+    # This is useful when these values can't be obtained by the disk check.
+    # Example: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html
+    # Note that it only works when the storage driver is devicemapper.
+    # Explanation of these metrics can be found here:
+    # https://github.com/docker/docker/blob/v1.11.1/daemon/graphdriver/devmapper/README.md
+    # Defaults to false.
+    #
+    # collect_disk_stats: true
+
 
     # Exclude containers based on their tags
     # An excluded container will be completely ignored. The rule is a regex on the tags.
@@ -101,6 +111,7 @@ instances:
     #   - docker_image: LEGACY. The full image name:tag string (example: "nginx:latest")
     #   - container_name: Name of the container (example: "boring_euclid")
     #   - container_command: Command ran by the container (example: "echo 1")
+    #   - container_id: Id of the container
     #
     # performance_tags: ["container_name", image_name", "image_tag", "docker_image"]
 
@@ -112,4 +123,4 @@ instances:
     # List of container label names that should be collected and sent as tags.
     # Default to None
     # Example:
-    # collect_labels_as_tags: ["com.docker.compose.service", "com.docker.compose.project"] 
+    # collect_labels_as_tags: ["com.docker.compose.service", "com.docker.compose.project"]

--- a/conf.d/docker_daemon.yaml
+++ b/conf.d/docker_daemon.yaml
@@ -58,6 +58,16 @@ instances:
     #
     # collect_image_size: false
 
+    # Collect disk metrics (total, used, free) through the docker info command for data and metadata.
+    # This is useful when these values can't be obtained by the disk check.
+    # Example: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html
+    # Note that it only works when the storage driver is devicemapper.
+    # Explanation of these metrics can be found here:
+    # https://github.com/docker/docker/blob/v1.11.1/daemon/graphdriver/devmapper/README.md
+    # Defaults to false.
+    #
+    # collect_disk_stats: true
+
 
     # Exclude containers based on their tags
     # An excluded container will be completely ignored. The rule is a regex on the tags.
@@ -101,6 +111,7 @@ instances:
     #   - docker_image: LEGACY. The full image name:tag string (example: "nginx:latest")
     #   - container_name: Name of the container (example: "boring_euclid")
     #   - container_command: Command ran by the container (example: "echo 1")
+    #   - container_id: Id of the container
     #
     # performance_tags: ["container_name", image_name", "image_tag", "docker_image"]
 
@@ -112,4 +123,4 @@ instances:
     # List of container label names that should be collected and sent as tags.
     # Default to None
     # Example:
-    # collect_labels_as_tags: ["com.docker.compose.service", "com.docker.compose.project"] 
+    # collect_labels_as_tags: ["com.docker.compose.service", "com.docker.compose.project"]


### PR DESCRIPTION
# Why this PR
We're refactoring the image tags to try and only have a handful of them. Thus using environment variables to enable checks instead of a separate tag (`mesos` in this case).

# What this PR will do
This PR makes it possible to enable the mesos slave and master checks through env variables, as well as the marathon and zookeeper ones. It basically updates the work of @alq666 in the branch `alq666/mesos` and integrates it in master.
It will be followed by a PR in the dcos universe repo to update the datadog task.