### PR TITLE
Add DD_HOSTNAME env var to alpine entrypoint

### DIFF
--- a/alpine/entrypoint.sh
+++ b/alpine/entrypoint.sh
@@ -12,6 +12,10 @@ else
 	exit 1
 fi
 
+if [[ $DD_HOSTNAME ]]; then
+	sed -i -e "s/^#hostname.*$/hostname: ${DD_HOSTNAME}/" /opt/datadog-agent/agent/datadog.conf
+fi
+
 if [[ $DD_TAGS ]]; then
   export TAGS=${DD_TAGS}
 fi


### PR DESCRIPTION
This option was present in the debian based image, adding it to the alpine one.