### PR TITLE
Support kubernetes check on main images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,8 +36,7 @@ COPY conf.d/docker_daemon.yaml /etc/dd-agent/conf.d/docker_daemon.yaml
 COPY entrypoint.sh /entrypoint.sh
 
 # Extra conf.d and checks.d
-VOLUME ["/conf.d"]
-VOLUME ["/checks.d"]
+VOLUME ["/conf.d", "/checks.d"]
 
 # Expose DogStatsD and supervisord ports
 EXPOSE 8125/udp 9001/tcp

--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ A few parameters can be changed with environment variables:
 
 It is also possible to enable some checks this way:
 
-* `MESOS_MASTER` and `MESOS_SLAVE` respectively enable the mesos master and mesos slave checks if set (`MESOS_MASTER=yes` will work).
+* `KUBERNETES` enables the kubernetes check if set (`KUBERNETES=yes` works)
+* `MESOS_MASTER` and `MESOS_SLAVE` respectively enable the mesos master and mesos slave checks if set (`MESOS_MASTER=yes` works).
 * `MARATHON_URL` if set will be used to enable the Marathon check that will query the URL passed in this variable for metrics. It can usually be set to `http://leader.mesos:8080`.
 
 **Note:** it is possible to use `DD_TAGS` instead of `TAGS`, `DD_LOG_LEVEL` instead of `LOG_LEVEL` and `DD_API_KEY` instead of `API_KEY`, these variables have the same impact.

--- a/alpine/entrypoint.sh
+++ b/alpine/entrypoint.sh
@@ -80,12 +80,16 @@ if [[ $STATSD_METRIC_NAMESPACE ]]; then
     sed -i -e "s/^# statsd_metric_namespace:.*$/statsd_metric_namespace: ${STATSD_METRIC_NAMESPACE}/" /opt/datadog-agent/agent/datadog.conf
 fi
 
-if [[ $MESOS_MASTER || $MESOS_SLAVE ]]; then
-    # expose supervisor as a health check
+if [[ $KUBERNETES || $MESOS_MASTER || $MESOS_SLAVE ]]; then
+    # expose supervisord as a health check
     echo "
 [inet_http_server]
 port = 0.0.0.0:9001
 " >> /opt/datadog-agent/agent/supervisor.conf
+fi
+
+if [[ $KUBERNETES ]]; then
+    cp /opt/datadog-agent/agent/conf.d/kubernetes.yaml.example /opt/datadog-agent/agent/conf.d/kubernetes.yaml
 fi
 
 if [[ $MESOS_MASTER ]]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -80,12 +80,17 @@ if [[ $STATSD_METRIC_NAMESPACE ]]; then
     sed -i -e "s/^# statsd_metric_namespace:.*$/statsd_metric_namespace: ${STATSD_METRIC_NAMESPACE}/" /etc/dd-agent/datadog.conf
 fi
 
-if [[ $MESOS_MASTER || $MESOS_SLAVE ]]; then
-    # expose supervisor as a health check
+if [[ $KUBERNETES || $MESOS_MASTER || $MESOS_SLAVE ]]; then
+    # expose supervisord as a health check
     echo "
 [inet_http_server]
 port = 0.0.0.0:9001
 " >> /etc/dd-agent/supervisor.conf
+fi
+
+if [[ $KUBERNETES ]]; then
+    # enable kubernetes check
+    cp /etc/dd-agent/conf.d/kubernetes.yaml.example /etc/dd-agent/conf.d/kubernetes.yaml
 fi
 
 if [[ $MESOS_MASTER ]]; then


### PR DESCRIPTION
# Why

To get rid of the kubernetes image and branch. This is part of the effort of reducing the number of different images we provide and merge them into a single one (or a few ones if necessary), controlled with environment variables.

# What
- Add the option to pass a `KUBERNETES` environment variable that will enable the kubernetes check if set
- Modify supervisor.conf to expose supervisord on `0.0.0.0:9001` when mesos or kubernetes checks are enabled (both for alpine and debian based images)
- Now the alpine-based image can be used too! (making `pullPolicy: Always` less painful)