### PR TITLE
use docker info or default gateway to guess host address

### DIFF
--- a/alpine/entrypoint.sh
+++ b/alpine/entrypoint.sh
@@ -1,6 +1,16 @@
 #!/bin/sh
 #set -e
 
+get_hostname () {
+    local host=`/opt/datadog-agent/embedded/bin/python -c "import docker;print docker.Client(version='auto').info().get('Name', '')"`
+    echo $host
+}
+
+get_default_gateway () {
+    local host=`ip route | grep default | cut -d' ' -f3`
+    echo $host
+}
+
 if [[ $DD_API_KEY ]]; then
   export API_KEY=${DD_API_KEY}
 fi
@@ -103,8 +113,16 @@ fi
 if [[ $MESOS_SLAVE ]]; then
     cp /opt/datadog-agent/agent/conf.d/mesos_slave.yaml.example /opt/datadog-agent/agent/conf.d/mesos_slave.yaml
 
-    # figure out hostname using the Docker info command
-    server=`/opt/datadog-agent/venv/bin/python -c "import docker;print docker.Client(version='auto').info().get('Name', '172.17.42.1')"`
+    # get hostname from the mesos IP endpoint
+    server=$(get_hostname)
+
+    # check if it resolves to the mesos slave
+    /opt/datadog-agent/embedded/bin/curl -I -s -m 1 http://$server:5051/state.json > /dev/null
+
+    # if it failed, try the hostname from docker info
+    if [[ $? != 0 ]]; then
+        server=$(get_default_gateway)
+    fi
 
     sed -i -e "s/localhost/$server/" /opt/datadog-agent/agent/conf.d/mesos_slave.yaml
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,16 @@
 #!/bin/bash
 #set -e
 
+function get_hostname {
+    local host=`/opt/datadog-agent/embedded/bin/python -c "import docker;print docker.Client(version='auto').info().get('Name', '')"`
+    echo $host
+}
+
+function get_default_gateway {
+    local host=`ip route | grep default | cut -d' ' -f3`
+    echo $host
+}
+
 if [[ $DD_API_KEY ]]; then
   export API_KEY=${DD_API_KEY}
 fi
@@ -104,8 +114,16 @@ fi
 if [[ $MESOS_SLAVE ]]; then
     cp /etc/dd-agent/conf.d/mesos_slave.yaml.example /etc/dd-agent/conf.d/mesos_slave.yaml
 
-    # figure out hostname using the Docker info command
-    server=`/opt/datadog-agent/embedded/bin/python -c "import docker;print docker.Client(version='auto').info().get('Name', '172.17.42.1')"`
+    # get hostname from the mesos IP endpoint
+    server=$(get_hostname)
+
+    # check if it resolves to the mesos slave
+    /opt/datadog-agent/embedded/bin/curl -I -s -m 1 http://$server:5051/state.json > /dev/null
+
+    # if it failed, try the hostname from docker info
+    if [[ $? != 0 ]]; then
+        server=$(get_default_gateway)
+    fi
 
     sed -i -e "s/localhost/$server/" /etc/dd-agent/conf.d/mesos_slave.yaml
 fi


### PR DESCRIPTION
in some setups, using the hostname from `docker info` doesn't work resolve to the host internal IP, so we fallback to the default gateway in this case.