### PR TITLE
Add retro-compatibility in entrypoint for older datadog.conf

### DIFF
--- a/alpine/entrypoint.sh
+++ b/alpine/entrypoint.sh
@@ -13,7 +13,7 @@ else
 fi
 
 if [[ $DD_HOSTNAME ]]; then
-	sed -i -e "s/^# hostname.*$/hostname: ${DD_HOSTNAME}/" /opt/datadog-agent/agent/datadog.conf
+	sed -i -r -e "s/^# ?hostname.*$/hostname: ${DD_HOSTNAME}/" /opt/datadog-agent/agent/datadog.conf
 fi
 
 if [[ $DD_TAGS ]]; then
@@ -25,7 +25,7 @@ if [[ $EC2_TAGS ]]; then
 fi
 
 if [[ $TAGS ]]; then
-	sed -i -e "s/^# tags:.*$/tags: ${TAGS}/" /opt/datadog-agent/agent/datadog.conf
+	sed -i -r -e "s/^# ?tags:.*$/tags: ${TAGS}/" /opt/datadog-agent/agent/datadog.conf
 fi
 
 if [[ $DD_LOG_LEVEL ]]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,7 +13,7 @@ else
 fi
 
 if [[ $DD_HOSTNAME ]]; then
-	sed -i -e "s/^# hostname.*$/hostname: ${DD_HOSTNAME}/" /etc/dd-agent/datadog.conf
+	sed -i -r -e "s/^# ?hostname.*$/hostname: ${DD_HOSTNAME}/" /etc/dd-agent/datadog.conf
 fi
 
 if [[ $DD_TAGS ]]; then
@@ -25,7 +25,7 @@ if [[ $EC2_TAGS ]]; then
 fi
 
 if [[ $TAGS ]]; then
-	sed -i -e "s/^# tags:.*$/tags: ${TAGS}/" /etc/dd-agent/datadog.conf
+	sed -i -r -e "s/^# ?tags:.*$/tags: ${TAGS}/" /etc/dd-agent/datadog.conf
 fi
 
 if [[ $DD_LOG_LEVEL ]]; then


### PR DESCRIPTION
datadog.conf layout was recently improved, making #100 necessary, but we still need to support older `datadog.conf` until https://github.com/DataDog/dd-agent/pull/2618 is released in version 5.9.0. This commit can be reverted once 5.9 is out.

Thank you @fotinakis for reporting this issue.