### PR TITLE
Provide env var to activate k8s event collector

### DIFF
--- a/alpine/entrypoint.sh
+++ b/alpine/entrypoint.sh
@@ -92,6 +92,7 @@ if [[ $KUBERNETES ]]; then
     cp /opt/datadog-agent/agent/conf.d/kubernetes.yaml.example /opt/datadog-agent/agent/conf.d/kubernetes.yaml
 
     # enable event collector
+    # WARNING: to avoid duplicates, only one agent at a time across the entire cluster should have this feature enabled.
     if [[ $KUBERNETES_COLLECT_EVENTS ]]; then
         sed -i -e "s@# collect_events: false@collect_events: true@" /opt/datadog-agent/agent/conf.d/kubernetes.yaml
     fi

--- a/alpine/entrypoint.sh
+++ b/alpine/entrypoint.sh
@@ -90,6 +90,11 @@ fi
 
 if [[ $KUBERNETES ]]; then
     cp /opt/datadog-agent/agent/conf.d/kubernetes.yaml.example /opt/datadog-agent/agent/conf.d/kubernetes.yaml
+
+    # enable event collector
+    if [[ $KUBERNETES_COLLECT_EVENTS ]]; then
+        sed -i -e "s@# collect_events: false@collect_events: true@" /opt/datadog-agent/agent/conf.d/kubernetes.yaml
+    fi
 fi
 
 if [[ $MESOS_MASTER ]]; then

--- a/alpine/entrypoint.sh
+++ b/alpine/entrypoint.sh
@@ -94,7 +94,7 @@ if [[ $KUBERNETES ]]; then
     # enable event collector
     # WARNING: to avoid duplicates, only one agent at a time across the entire cluster should have this feature enabled.
     if [[ $KUBERNETES_COLLECT_EVENTS ]]; then
-        sed -i -e "s@# collect_events: false@collect_events: true@" /opt/datadog-agent/agent/conf.d/kubernetes.yaml
+        sed -i -e "s@# collect_events: false@ collect_events: true@" /opt/datadog-agent/agent/conf.d/kubernetes.yaml
     fi
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -91,6 +91,11 @@ fi
 if [[ $KUBERNETES ]]; then
     # enable kubernetes check
     cp /etc/dd-agent/conf.d/kubernetes.yaml.example /etc/dd-agent/conf.d/kubernetes.yaml
+
+    # enable event collector
+    if [[ $KUBERNETES_COLLECT_EVENTS ]]; then
+        sed -i -e "s@# collect_events: false@collect_events: true@" /etc/dd-agent/conf.d/kubernetes.yaml
+    fi
 fi
 
 if [[ $MESOS_MASTER ]]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -95,7 +95,7 @@ if [[ $KUBERNETES ]]; then
     # enable event collector
     # WARNING: to avoid duplicates, only one agent at a time across the entire cluster should have this feature enabled.
     if [[ $KUBERNETES_COLLECT_EVENTS ]]; then
-        sed -i -e "s@# collect_events: false@collect_events: true@" /etc/dd-agent/conf.d/kubernetes.yaml
+        sed -i -e "s@# collect_events: false@ collect_events: true@" /etc/dd-agent/conf.d/kubernetes.yaml
     fi
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -93,6 +93,7 @@ if [[ $KUBERNETES ]]; then
     cp /etc/dd-agent/conf.d/kubernetes.yaml.example /etc/dd-agent/conf.d/kubernetes.yaml
 
     # enable event collector
+    # WARNING: to avoid duplicates, only one agent at a time across the entire cluster should have this feature enabled.
     if [[ $KUBERNETES_COLLECT_EVENTS ]]; then
         sed -i -e "s@# collect_events: false@collect_events: true@" /etc/dd-agent/conf.d/kubernetes.yaml
     fi


### PR DESCRIPTION
If the env var `KUBERNETES_COLLECT_EVENTS` is passed we set the `collect_events` config value to `True`.