### PR TITLE
andrew/update-docker-readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ By default the agent container will use the `Name` field found in the `docker in
 A few parameters can be changed with environment variables:
 
 * `DD_HOSTNAME` set the hostname (write it in `datadog.conf`)
-* `TAGS` set host tags. Add `-e TAGS="simple-tag-0,tag-key-1:tag-value-1"` to use [simple-tag-0, tag-key-1:tag-value-1] as host tags.
+* `TAGS` set host tags. Add `-e TAGS=simple-tag-0,tag-key-1:tag-value-1` to use [simple-tag-0, tag-key-1:tag-value-1] as host tags.
 * `EC2_TAGS` set EC2 host tags. Add `-e EC2_TAGS=yes` to use EC2 custom host tags. Requires an [IAM role](https://github.com/DataDog/dd-agent/wiki/Capturing-EC2-tags-at-startup) associated with the instance.
 * `LOG_LEVEL` set logging verbosity (CRITICAL, ERROR, WARNING, INFO, DEBUG). Add `-e LOG_LEVEL=DEBUG` to turn logs to debug mode.
 * `PROXY_HOST`, `PROXY_PORT`, `PROXY_USER` and `PROXY_PASSWORD` set the proxy configuration.


### PR DESCRIPTION
Removed tags from:

TAGS=

As it is incompatible with older Docker versions.  See:

https://datadog.zendesk.com/agent/tickets/62924