### PR TITLE
clarify readme around dogstatsd option and tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,8 @@ This option allows you to run dogstatsd alone, without supervisor. One consequen
 
 `docker logs dogstatsd`
 
+**Note**: This will run DogStatsD only. Tags are collected from the configuration file and from the Docker labels in the collector process which is not running when using this option. Thus those tags will not be associated with any metrics and events processed by this container.
+
 ### DogStatsD from the host
 
 DogStatsD can be available on port 8125 from anywhere by adding the option `-p 8125:8125/udp` to the `docker run` command.


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*


### What does this PR do?

This PR adds a note to the section on using dogstatsd only to say that it is not running the collector and thus will not observe the tags that are defined in the config.

### Motivation

I have seen a customer have trouble with the dogstatsd option because they expected tags and labels to be observed (https://hangops.slack.com/archives/datadog/p1473727086000014). Ilan told me there are others as well.

### Testing Guidelines

N/A

### Additional Notes

N/A
