### PR TITLE
[healtcheck] adding healthcheck - based on supervisor output.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,5 +39,11 @@ VOLUME ["/conf.d", "/checks.d"]
 # Expose DogStatsD and supervisord ports
 EXPOSE 8125/udp 9001/tcp
 
+# Healthcheck
+HEALTHCHECK --interval=5m --timeout=3s --retries=1 \
+  CMD test $(/opt/datadog-agent/embedded/bin/python /opt/datadog-agent/bin/supervisorctl \
+      -c /etc/dd-agent/supervisor.conf status | awk '{print $2}' | egrep -v 'RUNNING|EXITED' | wc -l) \
+      -eq 0 || exit 1
+
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["supervisord", "-n", "-c", "/etc/dd-agent/supervisor.conf"]

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -41,6 +41,12 @@ RUN cp "$DD_HOME/agent/datadog.conf.example" "$DD_HOME/agent/datadog.conf" \
   && rm "$DD_HOME/agent/conf.d/network.yaml.default" \
   && rm /tmp/setup_agent.sh
 
+# Healthcheck
+HEALTHCHECK --interval=5m --timeout=3s --retries=1 \
+  CMD test $($DD_HOME/venv/bin/python $DD_HOME/venv/bin/supervisorctl \
+      -c $DD_HOME/agent/supervisor.conf status | awk '{print $2}' | egrep -v 'RUNNING|EXITED' | wc -l) \
+      -eq 0 || exit 1
+
 # Extra conf.d and checks.d
 VOLUME ["/conf.d", "/checks.d"]
 

--- a/dogstatsd/Dockerfile
+++ b/dogstatsd/Dockerfile
@@ -33,6 +33,12 @@ RUN chmod g+w /etc/dd-agent/datadog.conf \
  && chmod g+w /etc/dd-agent \
  && chmod g+w /opt/datadog-agent/run/
 
+# Healthcheck
+HEALTHCHECK --interval=5m --timeout=3s --retries=1 \
+  CMD test $(/opt/datadog-agent/embedded/bin/python /opt/datadog-agent/bin/supervisorctl \
+      -c /etc/dd-agent/supervisor.conf status | awk '{print $2}' | egrep -v 'RUNNING|EXITED' | wc -l) \
+      -eq 0 || exit 1
+
 ENTRYPOINT ["/entrypoint.sh"]
 
 USER 1001


### PR DESCRIPTION
### What does this PR do?

This PR adds a docker healthcheck to our agent. It will rely on the supervisor output to determine the health of the agent processes.

### Motivation

Starting with docker 1.12, this has been made available and is a very helpful way to determine if your containers are in a sane state. We are also adding support for this in the dd-agent.

I _think_ that `supervisord` having pid 1 in the container means that we don't really need to check for the supervisor itself, because if that process would happen to die, the container would shutdown.

### Testing Guidelines

`docker inspect <containername>` should now report the health status in `{ 'State': { 'Health': {...} } }`

as well as creating events when the healthcheck reports the container status: `docker events`.
