### PR TITLE
Update sed command on `tags` of datadog.conf

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,7 +21,7 @@ if [[ $EC2_TAGS ]]; then
 fi
 
 if [[ $TAGS ]]; then
-	sed -i -e "s/^#tags:.*$/tags: ${TAGS}/" /etc/dd-agent/datadog.conf
+	sed -i -r -e "s/^# ?tags:.*$/tags: ${TAGS}/" /etc/dd-agent/datadog.conf
 fi
 
 if [[ $DD_LOG_LEVEL ]]; then


### PR DESCRIPTION
Was fixed on master but not backported to the `kubernetes` branch,
let's fix it since we've released a kubernetes image with a `5.9.0`
agent