### PR TITLE
Allow setting non_local_traffic: true

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ A few parameters can be changed with environment variables:
 * `PROXY_HOST`, `PROXY_PORT`, `PROXY_USER` and `PROXY_PASSWORD` set the proxy configuration.
 * `DD_URL` set the Datadog intake server to send Agent data to (used when [using an agent as a proxy](https://github.com/DataDog/dd-agent/wiki/Proxy-Configuration#using-the-agent-as-a-proxy) )
 * `DOGSTATSD_ONLY` tell the image to only start a standalone dogstatsd instance.
+* `NON_LOCAL_TRAFFIC` tells the image to set the `non_local_traffic: true` option, which enables statsd reporting from any external ip. You may find this useful to report metrics from your other containers. See [network configuration](https://github.com/DataDog/dd-agent/wiki/Network-Traffic-and-Proxy-Configuration) for more details.
 * `SD_BACKEND`, `SD_CONFIG_BACKEND`, `SD_BACKEND_HOST`, `SD_BACKEND_PORT` and `SD_TEMPLATE_DIR` configure service discovery.
 `SD_BACKEND` can only be set to `docker` for now, since service discovery works only with docker containers.
 `SD_CONFIG_BACKEND` can be set to `etcd` or `consul` which are the two configuration stores we support right now.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -40,6 +40,10 @@ if [[ $DD_URL ]]; then
     sed -i -e 's@^.*dd_url:.*$@dd_url: '${DD_URL}'@' /etc/dd-agent/datadog.conf
 fi
 
+if [[ $NON_LOCAL_TRAFFIC ]]; then
+    sed -i -e 's/^# non_local_traffic:.*$/non_local_traffic: true/' /etc/dd-agent/datadog.conf
+fi
+
 if [[ $PROXY_HOST ]]; then
     sed -i -e "s/^# proxy_host:.*$/proxy_host: ${PROXY_HOST}/" /etc/dd-agent/datadog.conf
 fi


### PR DESCRIPTION
### What does this PR do?

Allow setting the `non_local_traffic` config option.

### Motivation

This can be especially useful in dockerized environments if you want to report metrics from other containers. Seems like this would be a security risk to enable by default, so I'm leaving it as an opt-in.

### Testing Guidelines

Tested on my own docker image.

### Additional Notes

Not sure if it's worth defaulting this to true?