### PR TITLE
Enable k8s event collection based on a namspace name regex

### DIFF
--- a/alpine/entrypoint.sh
+++ b/alpine/entrypoint.sh
@@ -95,6 +95,11 @@ if [[ $KUBERNETES ]]; then
     # WARNING: to avoid duplicates, only one agent at a time across the entire cluster should have this feature enabled.
     if [[ $KUBERNETES_COLLECT_EVENTS ]]; then
         sed -i -e "s@# collect_events: false@ collect_events: true@" /opt/datadog-agent/agent/conf.d/kubernetes.yaml
+
+        # enable the namespace regex
+        if [[ $KUBERNETES_NAMESPACE_NAME_REGEX ]]; then
+            sed -i -e "s@# namespace_name_regexp:@ namespace_name_regexp: ${KUBERNETES_NAMESPACE_NAME_REGEX}" /etc/dd-agent/conf.d/kubernetes.yaml
+        fi
     fi
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -100,7 +100,13 @@ if [[ $KUBERNETES ]]; then
     # WARNING: to avoid duplicates, only one agent at a time across the entire cluster should have this feature enabled.
     if [[ $KUBERNETES_COLLECT_EVENTS ]]; then
         sed -i -e "s@# collect_events: false@ collect_events: true@" /etc/dd-agent/conf.d/kubernetes.yaml
+
+        # enable the namespace regex
+        if [[ $KUBERNETES_NAMESPACE_NAME_REGEX ]]; then
+            sed -i -e "s@# namespace_name_regexp:@ namespace_name_regexp: ${KUBERNETES_NAMESPACE_NAME_REGEX}" /etc/dd-agent/conf.d/kubernetes.yaml
+        fi
     fi
+
 fi
 
 if [[ $MESOS_MASTER ]]; then

--- a/jmx/entrypoint.sh
+++ b/jmx/entrypoint.sh
@@ -120,7 +120,12 @@ if [[ $KUBERNETES ]]; then
     # enable event collector
     # WARNING: to avoid duplicates, only one agent at a time across the entire cluster should have this feature enabled.
     if [[ $KUBERNETES_COLLECT_EVENTS ]]; then
-        sed -i -e "s@# collect_events: false@ collect_events: true@" /etc/dd-agent/conf.d/kubernetes.yaml
+        sed -i -e "s@# collect_events: false@ collect_events: true@" /opt/datadog-agent/agent/conf.d/kubernetes.yaml
+
+        # enable the namespace regex
+        if [[ $KUBERNETES_NAMESPACE_NAME_REGEX ]]; then
+            sed -i -e "s@# namespace_name_regexp:@ namespace_name_regexp: ${KUBERNETES_NAMESPACE_NAME_REGEX}" /etc/dd-agent/conf.d/kubernetes.yaml
+        fi
     fi
 fi
 


### PR DESCRIPTION
### What does this PR do?

Enables the Kubernetes Namespace name Regex for event collection in the docker image via environment variables

### Motivation

Make easier to use the DDAgent image for Kubernetes

### Additional Notes

To be merged after ~5.11 is released; https://github.com/DataDog/dd-agent/milestone/76~ 5.12 is released, https://github.com/DataDog/dd-agent/milestone/79