### PR TITLE
Document the KUBERNETES_COLLECT_EVENTS env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Some configuration parameters can be changed with environment variables:
 
 It is possible to enable some checks through the environment:
 
-* `KUBERNETES` enables the kubernetes check if set (`KUBERNETES=yes` works)
+* `KUBERNETES` enables the kubernetes check if set (`KUBERNETES=yes` works). `KUBERNETES_COLLECT_EVENTS` enables event collection from the kubernetes API, given that `KUBERNETES` is also set. **Note:** only one agent should have `KUBERNETES_COLLECT_EVENTS` set per cluster.
 * `MESOS_MASTER` and `MESOS_SLAVE` respectively enable the mesos master and mesos slave checks if set (`MESOS_MASTER=yes` works).
 * `MARATHON_URL` if set will be used to enable the Marathon check that will query the URL passed in this variable for metrics. It can usually be set to `http://leader.mesos:8080`.
 


### PR DESCRIPTION
I was considering building a Docker image extending this one to have environment-selectable `collect_events` behavior, but it turned out `docker-dd-agent` already supports it! This adds documentation to make it easier for the next person to realize the same thing.