### PR TITLE
Added support for EC2 host IP automatic detection for SD_CONFIG_BACKEND

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ ENV DOCKER_DD_AGENT=yes \
 RUN echo "deb http://apt.datadoghq.com/ stable main" > /etc/apt/sources.list.d/datadog.list \
  && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C7A7DA52 \
  && apt-get update \
- && apt-get install --no-install-recommends -y curl \
  && apt-get install --no-install-recommends -y datadog-agent="${AGENT_VERSION}" \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ ENV DOCKER_DD_AGENT=yes \
 RUN echo "deb http://apt.datadoghq.com/ stable main" > /etc/apt/sources.list.d/datadog.list \
  && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C7A7DA52 \
  && apt-get update \
+ && apt-get install --no-install-recommends -y curl \
  && apt-get install --no-install-recommends -y datadog-agent="${AGENT_VERSION}" \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/alpine/entrypoint.sh
+++ b/alpine/entrypoint.sh
@@ -76,7 +76,7 @@ fi
 if [[ $SD_CONFIG_BACKEND ]]; then
     sed -i -e "s/^# sd_config_backend:.*$/sd_config_backend: ${SD_CONFIG_BACKEND}/" /opt/datadog-agent/agent/datadog.conf
     # If no SD_BACKEND_HOST value is defined AND running in EC2 and host ip is available AND sd_backend is 'consul'
-    if [[ -z $SD_BACKEND_HOST && -n $EC2_HOST_IP && "$SD_CONFIG_BACKEND" == "consul" ]]; then
+    if [[ -z $SD_BACKEND_HOST && -n $EC2_HOST_IP ]]; then
         export SD_BACKEND_HOST="$EC2_HOST_IP"
     fi
 fi

--- a/alpine/entrypoint.sh
+++ b/alpine/entrypoint.sh
@@ -75,7 +75,7 @@ fi
 
 if [[ $SD_CONFIG_BACKEND ]]; then
     sed -i -e "s/^# sd_config_backend:.*$/sd_config_backend: ${SD_CONFIG_BACKEND}/" /opt/datadog-agent/agent/datadog.conf
-    # If no SD_BACKEND_HOST value is defined AND running in EC2 and host ip is available AND sd_backend is 'consul'
+    # If no SD_BACKEND_HOST value is defined AND running in EC2 and host ip is available
     if [[ -z $SD_BACKEND_HOST && -n $EC2_HOST_IP ]]; then
         export SD_BACKEND_HOST="$EC2_HOST_IP"
     fi

--- a/alpine/entrypoint.sh
+++ b/alpine/entrypoint.sh
@@ -56,12 +56,18 @@ if [[ $PROXY_PASSWORD ]]; then
     sed -i -e "s/^# proxy_password:.*$/proxy_password: ${PROXY_PASSWORD}/" /opt/datadog-agent/agent/datadog.conf
 fi
 
+EC2_HOST_IP=`curl --silent http://169.254.169.254/latest/meta-data/local-ipv4 --max-time 1`
+
 if [[ $SD_BACKEND ]]; then
     sed -i -e "s/^# service_discovery_backend:.*$/service_discovery_backend: ${SD_BACKEND}/" /opt/datadog-agent/agent/datadog.conf
 fi
 
 if [[ $SD_CONFIG_BACKEND ]]; then
     sed -i -e "s/^# sd_config_backend:.*$/sd_config_backend: ${SD_CONFIG_BACKEND}/" /opt/datadog-agent/agent/datadog.conf
+    # If no SD_BACKEND_HOST value is defined AND running in EC2 and host ip is available AND sd_backend is 'consul'
+    if [[ -z $SD_BACKEND_HOST && -n $EC2_HOST_IP && "$SD_CONFIG_BACKEND" == "consul" ]]; then
+        export SD_BACKEND_HOST="$EC2_HOST_IP"
+    fi
 fi
 
 if [[ $SD_BACKEND_HOST ]]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -72,6 +72,7 @@ fi
 
 
 ##### Service discovery #####
+EC2_HOST_IP=`curl --silent http://169.254.169.254/latest/meta-data/local-ipv4 --max-time 1`
 
 if [[ $SD_BACKEND ]]; then
     sed -i -e "s/^# service_discovery_backend:.*$/service_discovery_backend: ${SD_BACKEND}/" /etc/dd-agent/datadog.conf
@@ -79,6 +80,10 @@ fi
 
 if [[ $SD_CONFIG_BACKEND ]]; then
     sed -i -e "s/^# sd_config_backend:.*$/sd_config_backend: ${SD_CONFIG_BACKEND}/" /etc/dd-agent/datadog.conf
+    # If no SD_BACKEND_HOST value is defined AND running in EC2 and host ip is available AND sd_backend is 'consul'
+    if [[ -z $SD_BACKEND_HOST && -n $EC2_HOST_IP && "$SD_CONFIG_BACKEND" == "consul" ]]; then
+        export SD_BACKEND_HOST="$EC2_HOST_IP"
+    fi
 fi
 
 if [[ $SD_BACKEND_HOST ]]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -81,7 +81,7 @@ fi
 if [[ $SD_CONFIG_BACKEND ]]; then
     sed -i -e "s/^# sd_config_backend:.*$/sd_config_backend: ${SD_CONFIG_BACKEND}/" /etc/dd-agent/datadog.conf
     # If no SD_BACKEND_HOST value is defined AND running in EC2 and host ip is available AND sd_backend is 'consul'
-    if [[ -z $SD_BACKEND_HOST && -n $EC2_HOST_IP && "$SD_CONFIG_BACKEND" == "consul" ]]; then
+    if [[ -z $SD_BACKEND_HOST && -n $EC2_HOST_IP ]]; then
         export SD_BACKEND_HOST="$EC2_HOST_IP"
     fi
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -72,7 +72,7 @@ fi
 
 
 ##### Service discovery #####
-EC2_HOST_IP=`curl --silent http://169.254.169.254/latest/meta-data/local-ipv4 --max-time 1`
+EC2_HOST_IP=`/opt/datadog-agent/embedded/bin/curl --silent http://169.254.169.254/latest/meta-data/local-ipv4 --max-time 1`
 
 if [[ $SD_BACKEND ]]; then
     sed -i -e "s/^# service_discovery_backend:.*$/service_discovery_backend: ${SD_BACKEND}/" /etc/dd-agent/datadog.conf

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -80,7 +80,7 @@ fi
 
 if [[ $SD_CONFIG_BACKEND ]]; then
     sed -i -e "s/^# sd_config_backend:.*$/sd_config_backend: ${SD_CONFIG_BACKEND}/" /etc/dd-agent/datadog.conf
-    # If no SD_BACKEND_HOST value is defined AND running in EC2 and host ip is available AND sd_backend is 'consul'
+    # If no SD_BACKEND_HOST value is defined AND running in EC2 and host ip is available
     if [[ -z $SD_BACKEND_HOST && -n $EC2_HOST_IP ]]; then
         export SD_BACKEND_HOST="$EC2_HOST_IP"
     fi


### PR DESCRIPTION
This PR addresses issue #151

Automatically detect EC2 host IP for local consul agent when running in ECS