### PR TITLE
[alpine] fix missing curl dependency.

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -19,10 +19,10 @@ COPY entrypoint.sh /entrypoint.sh
 EXPOSE 9001/tcp 8125/udp
 
 # Install minimal dependencies
-RUN apk add -qU --no-cache curl-dev python-dev tar sysstat
+RUN apk add -qU --no-cache curl curl-dev python-dev tar sysstat
 
 # Install build dependencies
-RUN apk add -qU --no-cache -t .build-deps curl gcc musl-dev pgcluster-dev linux-headers \
+RUN apk add -qU --no-cache -t .build-deps gcc musl-dev pgcluster-dev linux-headers \
     # Install the agent
     && sh /tmp/setup_agent.sh \
     # Clean build dependencies


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*


### What does this PR do?

Add curl as a long-term dependency

### Motivation

curl used to be a build dependency only, but we now use it in the entrypoint so let's keep it.

Fix #156 