### PR TITLE
fix alpine entrypoint

### DIFF
--- a/alpine/entrypoint.sh
+++ b/alpine/entrypoint.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 #set -e
+set -x
 
 
 ##### Core config #####

--- a/alpine/entrypoint.sh
+++ b/alpine/entrypoint.sh
@@ -2,7 +2,6 @@
 #set -e
 set -x
 
-
 ##### Core config #####
 
 if [[ $DD_API_KEY ]]; then
@@ -101,7 +100,7 @@ fi
 
 ##### Integrations config #####
 
-if [[ $KUBERNETES || $MESOS_MASTER || $MESOS_SLAVE ]]; then
+if [[ -n "${KUBERNETES}" || -n "${MESOS_MASTER}" || -n "${MESOS_SLAVE}" ]]; then
     # expose supervisord as a health check
     echo "
 [inet_http_server]


### PR DESCRIPTION
### What does this PR do?

Basically if condition fails. It's becase Busybox's sh != sh 3.x

```
+ [[ ]]
+ [[ XXXXXXXXXXXXXXXXXX ]]
+ sed -i -e s/^.*api_key:.*$/api_key: XXXXXXXXXXXXXXXXXX/ /opt/datadog-agent/agent/datadog.conf
+ [[ NAMENAMENAMENAME ]]
+ sed -i -r -e s/^# ?hostname.*$/hostname: NAMENAMENAMENAME/ /opt/datadog-agent/agent/datadog.conf
+ [[ ]]
+ [[ yes ]]
+ sed -i -e s/^# collect_ec2_tags.*$/collect_ec2_tags: yes/ /opt/datadog-agent/agent/datadog.conf
+ [[ os-name:CoreOS,os-version:NNNN.N.0 ]]
+ sed -i -r -e s/^# ?tags:.*$/tags: os-name:CoreOS,os-version:NNNN.N.0/ /opt/datadog-agent/agent/datadog.conf
+ [[ ]]
+ [[ ]]
+ [[ ]]
+ [[ ]]
+ [[ ]]
+ [[ ]]
+ [[ ]]
+ [[ ]]
+ curl --silent http://169.254.169.254/latest/meta-data/local-ipv4 --max-time 1
+ EC2_HOST_IP=NNN.NNN.NNN.NNN
+ [[ ]]
+ [[ ]]
+ [[ ]]
+ [[ ]]
+ [[ ]]
+ [[ ]]
+ [[ -o -o ]]
sh: argument expected
+ [[ ]]
+ [[ ]]
+ [[ ]]
+ [[ ]]
+ find /conf.d -name *.yaml -exec cp --parents {} /opt/datadog-agent/agent ;
+ find /checks.d -name *.py -exec cp {} /opt/datadog-agent/agent/checks.d ;
+ export PATH=/opt/datadog-agent/embedded/bin:/opt/datadog-agent/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ [[ ]]
+ exec /bin/sh -c source venv/bin/activate && supervisord -c agent/supervisor.conf
```

Here is it proof 
```
/opt/datadog-agent # cat /tmp/a.sh
cat /tmp/a.sh
if [[ $KUBERNETES || $MESOS_MASTER || $MESOS_SLAVE ]]; then
    # expose supervisord as a health check
    echo "
[inet_http_server]
port = 0.0.0.0:9001
" >> /opt/datadog-agent/agent/supervisor.conf
fi
/opt/datadog-agent # sh -x /tmp/a.sh
sh -x /tmp/a.sh
+ [[ -o -o ]]
sh: argument expected
```

but 

```
/opt/datadog-agent # cat /tmp/b.sh
cat /tmp/b.sh
if [[ "${KUBERNETES}" || "${MESOS_MASTER}" || "${MESOS_SLAVE}" ]]; then
    # expose supervisord as a health check
    echo "
[inet_http_server]
port = 0.0.0.0:9001
" >> /opt/datadog-agent/agent/supervisor.conf
fi
/opt/datadog-agent # sh -x /tmp/b.sh
sh -x /tmp/b.sh
+ [[  -o  -o  ]]
```

### Motivation

Fail is enough to fix, isn't it?