### PR TITLE
Add a JMX flavor that ships with a JRE

### DIFF
--- a/jmx/Dockerfile
+++ b/jmx/Dockerfile
@@ -1,0 +1,50 @@
+FROM debian:jessie
+
+MAINTAINER Datadog <package@datadoghq.com>
+
+ENV DOCKER_DD_AGENT=yes \
+    AGENT_VERSION=1:5.10.1-1
+
+# Install the Agent
+RUN echo "deb http://apt.datadoghq.com/ stable main" > /etc/apt/sources.list.d/datadog.list \
+ && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C7A7DA52 \
+ && apt-get update \
+ && apt-get install --no-install-recommends -y openjdk-7-jre-headless \
+ && apt-get install --no-install-recommends -y datadog-agent="${AGENT_VERSION}" \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Configure the Agent
+# 1. Listen to statsd from other containers
+# 2. Turn syslog off
+# 3. Remove dd-agent user from supervisor configuration
+# 4. Remove dd-agent user from init.d configuration
+# 5. Fix permission on /etc/init.d/datadog-agent
+# 6. Remove network check
+RUN mv /etc/dd-agent/datadog.conf.example /etc/dd-agent/datadog.conf \
+ && sed -i -e"s/^.*non_local_traffic:.*$/non_local_traffic: yes/" /etc/dd-agent/datadog.conf \
+ && sed -i -e"s/^.*log_to_syslog:.*$/log_to_syslog: no/" /etc/dd-agent/datadog.conf \
+ && sed -i "/user=dd-agent/d" /etc/dd-agent/supervisor.conf \
+ && sed -i 's/AGENTUSER="dd-agent"/AGENTUSER="root"/g' /etc/init.d/datadog-agent \
+ && chmod +x /etc/init.d/datadog-agent \
+ && rm /etc/dd-agent/conf.d/network.yaml.default
+
+# Add Docker check
+COPY conf.d/docker_daemon.yaml /etc/dd-agent/conf.d/docker_daemon.yaml
+
+COPY entrypoint.sh /entrypoint.sh
+
+# Extra conf.d and checks.d
+VOLUME ["/conf.d", "/checks.d"]
+
+# Expose DogStatsD and supervisord ports
+EXPOSE 8125/udp 9001/tcp
+
+# Healthcheck
+HEALTHCHECK --interval=5m --timeout=3s --retries=1 \
+  CMD test $(/opt/datadog-agent/embedded/bin/python /opt/datadog-agent/bin/supervisorctl \
+      -c /etc/dd-agent/supervisor.conf status | awk '{print $2}' | egrep -v 'RUNNING|EXITED' | wc -l) \
+      -eq 0 || exit 1
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["supervisord", "-n", "-c", "/etc/dd-agent/supervisor.conf"]

--- a/jmx/conf.d/docker_daemon.yaml
+++ b/jmx/conf.d/docker_daemon.yaml
@@ -1,0 +1,126 @@
+init_config:
+  # Change the root directory to look at to get cgroup statistics. Useful when running inside a
+  # container with host directories mounted on a different folder. Default: /.
+  # Example for the docker-dd-agent container:
+  docker_root: /host
+
+  # Timeout in seconds for the connection to the docker daemon
+  # Default: 5 seconds
+  #
+  # timeout: 10
+
+  # The version of the API the client will use. Specify 'auto' to use the API version provided by the server.
+  # api_version: auto
+
+  # Use TLS encryption while communicating with the Docker API
+  #
+  # tls: False
+  # tls_client_cert: /path/to/client-cert.pem
+  # tls_client_key: /path/to/client-key.pem
+  # tls_cacert: /path/to/ca.pem
+  # tls_verify: True
+
+instances:
+  - ## Daemon and system configuration
+    ##
+
+    # URL of the Docker daemon socket to reach the Docker API. HTTP/HTTPS also works.
+    # Warning: if that's a non-local daemon, we won't be able to collect performance metrics.
+    #
+    url: "unix://var/run/docker.sock"
+
+    ## Data collection
+    ##
+
+    # Create events whenever a container status change.
+    # Defaults to true.
+    #
+    # collect_events: false
+
+    # Collect disk usage per container with docker.container.size_rw and
+    # docker.container.size_rootfs metrics.
+    # Warning: This might take time for Docker daemon to generate,
+    # ensure that `docker ps -a -q` run fast before enabling it.
+    # Defaults to false.
+    #
+    # collect_container_size: false
+
+    # Collect images stats
+    # Number of available active images and intermediate images as gauges.
+    # Defaults to false.
+    #
+    # collect_images_stats: false
+
+    # Collect disk usage per image with docker.image.size and docker.image.virtual_size metrics.
+    # The check gets this size with the `docker images` command.
+    # Requires collect_images_stats to be enabled.
+    # Defaults to false.
+    #
+    # collect_image_size: false
+
+    # Collect disk metrics (total, used, free) through the docker info command for data and metadata.
+    # This is useful when these values can't be obtained by the disk check.
+    # Example: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html
+    # Note that it only works when the storage driver is devicemapper.
+    # Explanation of these metrics can be found here:
+    # https://github.com/docker/docker/blob/v1.11.1/daemon/graphdriver/devmapper/README.md
+    # Defaults to false.
+    #
+    # collect_disk_stats: true
+
+
+    # Exclude containers based on their tags
+    # An excluded container will be completely ignored. The rule is a regex on the tags.
+    #
+    # How it works: exclude first.
+    # If a tag matches an exclude rule, it won't be included unless it also matches an include rule.
+    # Examples:
+    # exclude all, except ubuntu and debian.
+    # exclude: [".*"]
+    # include: ["docker_image:ubuntu", "docker_image:debian"]
+    #
+    # include all, except ubuntu and debian.
+    # exclude: ["docker_image:ubuntu", "docker_image:debian"]
+    # include: []
+    #
+    # Default: include all containers
+
+
+
+    ## Tagging
+    ##
+
+    # You can add extra tags to your Docker metrics with the tags list option.
+    # Example: ["extra_tag", "env:testing"]
+    #
+    # tags: []
+
+    # If the agent is running in an Amazon ECS task, tags container metrics with the ECS task name and version.
+    # Default: true
+    #
+    # ecs_tags: false
+
+    # Custom metrics tagging
+    # Define which Docker tags to apply on metrics.
+    # Since it impacts the aggregation, modify it carefully (only if you really need it).
+    #
+    # Tags for performance metrics.
+    # Available:
+    #   - image_name: Name of the image (example: "nginx")
+    #   - image_tag: Tag of the image (example: "latest")
+    #   - docker_image: LEGACY. The full image name:tag string (example: "nginx:latest")
+    #   - container_name: Name of the container (example: "boring_euclid")
+    #   - container_command: Command ran by the container (example: "echo 1")
+    #   - container_id: Id of the container
+    #
+    # performance_tags: ["container_name", image_name", "image_tag", "docker_image"]
+
+    # Tags for containers count metrics.
+    # Available: ["image_name", "image_tag", "docker_image", "container_command"]
+    #
+    # container_tags: ["image_name", "image_tag", "docker_image"]
+
+    # List of container label names that should be collected and sent as tags.
+    # Default to None
+    # Example:
+    # collect_labels_as_tags: ["com.docker.compose.service", "com.docker.compose.project"]

--- a/jmx/examples/apache/Dockerfile
+++ b/jmx/examples/apache/Dockerfile
@@ -1,0 +1,8 @@
+# Example - Apache
+#
+# Agent running an Apache check
+
+FROM datadog/docker-dd-agent
+
+# Add Apache check configuration
+ADD apache.yaml /etc/dd-agent/conf.d/apache.yaml

--- a/jmx/examples/apache/apache.yaml
+++ b/jmx/examples/apache/apache.yaml
@@ -1,0 +1,8 @@
+init_config:
+
+instances:
+    -   apache_status_url: http://172.17.42.1/server-status?auto
+        # apache_user: example_user
+        # apache_password: example_password
+        tags:
+            -   instance:foo

--- a/jmx/examples/complex/Dockerfile
+++ b/jmx/examples/complex/Dockerfile
@@ -1,0 +1,8 @@
+# Example - Complex
+#
+# Agent running with a more complex configuration
+
+FROM datadog/docker-dd-agent
+
+# Add a constom datadog.conf
+ADD datadog.conf /etc/dd-agent/datadog.conf

--- a/jmx/examples/complex/datadog.conf
+++ b/jmx/examples/complex/datadog.conf
@@ -1,0 +1,19 @@
+[Main]
+dd_url: https://app.datadoghq.com
+
+proxy_host: my-proxy.com
+proxy_port: 3128
+proxy_user: user
+proxy_password: password
+
+api_key: EXAMPLE_API_KEY
+
+use_mount: no
+
+log_level: INFO
+
+collector_log_file: /opt/log/datadog/collector.log
+forwarder_log_file: /opt/log/datadog/forwarder.log
+dogstatsd_log_file: /opt/log/datadog/dogstatsd.log
+
+log_to_syslog: no

--- a/jmx/examples/kafka/Dockerfile
+++ b/jmx/examples/kafka/Dockerfile
@@ -1,0 +1,12 @@
+# Example - Kafka
+#
+# Agent running a Kafka check
+
+FROM datadog/docker-dd-agent
+
+# Install JMXFetch dependencies
+RUN apt-get update -qq && apt-get install openjdk-7-jre-headless -y -qq --no-install-recommends
+
+# Add Kafka check configuration
+ADD kafka.yaml /etc/dd-agent/conf.d/kafka.yaml
+

--- a/jmx/examples/kafka/kafka.yaml
+++ b/jmx/examples/kafka/kafka.yaml
@@ -1,0 +1,25 @@
+
+instances:
+   -   host: 172.17.42.1
+       port: 9999
+#        name: jmx_instance
+#        user: username
+#        password: password
+#        #java_bin_path: /path/to/java #Optional, should be set if the agent cannot find your java executable
+#        #trust_store_path: /path/to/trustStore.jks # Optional, should be set if ssl is enabled
+#        #trust_store_password: password
+#        tags:
+#             env: stage
+#             newTag: test
+
+
+init_config:
+    is_jmx: true
+    conf:
+        - include:
+            domain: '"kafka.server"'
+            bean: '"kafka.server":type="BrokerTopicMetrics",name="AllTopicsBytesOutPerSec"'
+            attribute:
+                MeanRate:
+                    metric_type: counter
+                    alias: kafka.net.bytes_out

--- a/jmx/examples/mysql/Dockerfile
+++ b/jmx/examples/mysql/Dockerfile
@@ -1,0 +1,8 @@
+# Example - MySQL
+#
+# Agent running a MySQL check
+
+FROM datadog/docker-dd-agent
+
+# Add MySQL check configuration
+ADD mysql.yaml /etc/dd-agent/conf.d/mysql.yaml

--- a/jmx/examples/mysql/mysql.yaml
+++ b/jmx/examples/mysql/mysql.yaml
@@ -1,0 +1,12 @@
+init_config:
+
+instances:
+  - server: 172.17.42.1
+    user: datadog
+    pass: password
+    tags:
+        - optional_tag1
+        - optional_tag2
+    options:
+        replication: 0
+        galera_cluster: 1/


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*


### What does this PR do?

Ship JRE in a jmx flavored tag

### Motivation

jmx integrations need it, and jmx service discovery will soon go out. Also fix #159.
