### PR TITLE
Add trace-agent to container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN echo "deb http://apt.datadoghq.com/ stable main" > /etc/apt/sources.list.d/d
  && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C7A7DA52 \
  && apt-get update \
  && apt-get install --no-install-recommends -y datadog-agent="${AGENT_VERSION}" \
+ && apt-get install --no-install-recommends -y ca-certificates \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ COPY entrypoint.sh /entrypoint.sh
 # Extra conf.d and checks.d
 VOLUME ["/conf.d", "/checks.d"]
 
-# Expose DogStatsD and supervisord ports
+# Expose DogStatsD, supervisord and trace-agent ports
 EXPOSE 8125/udp 9001/tcp 8126/tcp 7777/tcp
 
 # Healthcheck

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:jessie
 MAINTAINER Datadog <package@datadoghq.com>
 
 ENV DOCKER_DD_AGENT=yes \
-    AGENT_VERSION=1:5.10.1-1
+    AGENT_VERSION=1:5.11.0-1
 
 # Install the Agent
 RUN echo "deb http://apt.datadoghq.com/ stable main" > /etc/apt/sources.list.d/datadog.list \
@@ -14,7 +14,7 @@ RUN echo "deb http://apt.datadoghq.com/ stable main" > /etc/apt/sources.list.d/d
  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Configure the Agent
-# 1. Listen to statsd from other containers
+# 1. Listen to statsd (8125) and traces (8126 and 7777) from other containers
 # 2. Turn syslog off
 # 3. Remove dd-agent user from supervisor configuration
 # 4. Remove dd-agent user from init.d configuration
@@ -37,7 +37,7 @@ COPY entrypoint.sh /entrypoint.sh
 VOLUME ["/conf.d", "/checks.d"]
 
 # Expose DogStatsD and supervisord ports
-EXPOSE 8125/udp 9001/tcp
+EXPOSE 8125/udp 9001/tcp 8126/tcp 7777/tcp
 
 # Healthcheck
 HEALTHCHECK --interval=5m --timeout=3s --retries=1 \

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Since the Agent container port 8125 should be linked to the host directly, you c
 
 ## Tracing + APM
 
-Enable the (datadog-trace-agent)[https://github.com/DataDog/datadog-trace-agent] in the `docker-dd-agent` container by passing
+Enable the [datadog-trace-agent](https://github.com/DataDog/datadog-trace-agent) in the `docker-dd-agent` container by passing
 `DD_APM_ENABLED=true` as an environment variable
 
 ### Tracing from the host

--- a/README.md
+++ b/README.md
@@ -149,9 +149,9 @@ Enable the [datadog-trace-agent](https://github.com/DataDog/datadog-trace-agent)
 
 ### Tracing from the host
 
-Tracing can be available on port 8126/tcp from anywhere by adding the option `-p 8126:8126/tcp` to the `docker run` command
+Tracing can be available on ports 7777/tcp and 8126/tcp from anywhere by adding the options `-p 7777:7777/tcp -p 8126:8126/tcp` to the `docker run` command
 
-To make it available from your host only, use `-p 127.0.0.1:8126:8126/tcp` instead.
+To make it available from your host only, use `-p 127.0.0.1:7777:7777/tcp -p 127.0.0.1:8126:8126/tcp` instead.
 
 For example, the following command will allow the agent to receive traces from anywhere
 
@@ -167,8 +167,8 @@ docker run -d --name dd-agent \
 ```
 
 Port 7777 is a legacy port used by former client libraries and is being replaced by 8126.
-As a transition, it is safer to expose both ports, unless you explicitely parameter your
-client code to use port 8126, or make sure your client library uses 8126 by default.
+For now, it is safer to expose both ports, unless you explicitly configure your
+client to use port 8126. Future client libraries will report to port 8126 by default.
 
 ### Tracing from other containers
 As with DogStatsD, traces can be submitted to the agent from other containers either

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -156,10 +156,9 @@ if [[ -z $DD_HOSTNAME && $DD_APM_ENABLED ]]; then
         # When starting up the trace-agent without an explicit hostname
         # we need to ensure that the trace-agent will report as the same host as the
         # infrastructure agent.
-        # To do this, we execute some of dd-agent's python code and plug the hostname
-        # into the common configuration file
-        new_hostname=`PYTHONPATH=/opt/datadog-agent/agent /opt/datadog-agent/embedded/bin/python -c "from utils.hostname import get_hostname; print get_hostname()"`
-	sed -i -r -e "s/^# ?hostname.*$/hostname: ${new_hostname}/" /etc/dd-agent/datadog.conf
+        # To do this, we execute some of dd-agent's python code and expose the hostname
+        # as an env var
+        export DD_HOSTNAME=`PYTHONPATH=/opt/datadog-agent/agent /opt/datadog-agent/embedded/bin/python -c "from utils.hostname import get_hostname; print get_hostname()"`
 fi
 
 if [[ $DOGSTATSD_ONLY ]]; then


### PR DESCRIPTION
[DO NOT MERGE]

- Ensure trace-agent starts with same hostname as infra agent
- Expose trace-agent ports and bump version