### PR TITLE
Added missing dependency pycurl

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -19,7 +19,7 @@ COPY entrypoint.sh /entrypoint.sh
 EXPOSE 9001/tcp 8125/udp
 
 # Install minimal dependencies
-RUN apk add -qU --no-cache curl curl-dev python-dev tar sysstat
+RUN apk add -qU --no-cache curl curl-dev python-dev py-curl tar sysstat
 
 # Install build dependencies
 RUN apk add -qU --no-cache -t .build-deps gcc musl-dev pgcluster-dev linux-headers \


### PR DESCRIPTION
Adds the missing py-curl dependency for the Alpine image.

Closes https://github.com/DataDog/docker-dd-agent/issues/166
