### PR TITLE
[alpine] Make sure pycurl is installed with openssl backend

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -6,7 +6,8 @@ ENV DD_HOME=/opt/datadog-agent \
     # prevent the agent from being started after install
     DD_START_AGENT=0 \
     DOCKER_DD_AGENT=yes \
-    AGENT_VERSION=5.10.1
+    AGENT_VERSION=5.10.1 \
+    PYCURL_SSL_LIBRARY=openssl
 
 # Add Docker check
 COPY conf.d/docker_daemon.yaml "$DD_HOME/agent/conf.d/docker_daemon.yaml"


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*


### What does this PR do?

Fix pycurl import error.
pycurl failed to be imported because the one we install doesn't use openssl as a backend. Setting `PYCURL_SSL_LIBRARY` before running `setup_agent.sh` fixes the issue.

### Motivation

Closes #166 