### PR TITLE
Fix missing slash in dockerfile

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -6,8 +6,8 @@ ENV DD_HOME=/opt/datadog-agent \
     # prevent the agent from being started after install
     DD_START_AGENT=0 \
     DOCKER_DD_AGENT=yes \
+    PYCURL_SSL_LIBRARY=openssl \
     AGENT_VERSION=5.11.0
-    PYCURL_SSL_LIBRARY=openssl
 
 # Add Docker check
 COPY conf.d/docker_daemon.yaml "$DD_HOME/agent/conf.d/docker_daemon.yaml"


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*


### What does this PR do?

A bug in the jenkins job that triggers docker releases removed a slash. Adding it back.


### Motivation

Broken build
