### PR TITLE
Add option to redirect agent's logs to stdout/stderr to be captured in container's logs

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -46,7 +46,6 @@ fi
 if [[ $LOGS_STDOUT == "yes" ]]; then
   sed -i -e "/^.*_logfile.*$/d" /etc/dd-agent/supervisor.conf
   sed -i -e "/^.*\[program:.*\].*$/a stdout_logfile=\/dev\/stdout\nstdout_logfile_maxsize=0\nstderr_logfile=\/dev\/stderr\nstderr_logfile_maxsize=0" /etc/dd-agent/supervisor.conf
-  sed -i -e "$ a disable_file_logging: yes" /etc/dd-agent/datadog.conf
 fi
 
 if [[ $DD_URL ]]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -45,7 +45,7 @@ fi
 
 if [[ $LOGS_STDOUT == "yes" ]]; then
   sed -i -e "/^.*_logfile.*$/d" /etc/dd-agent/supervisor.conf
-  sed -i -e "/^.*\[program:.*\].*$/a stdout_logfile=\/dev\/stdout\nstdout_logfile_maxsize=0\nstderr_logfile=\/dev\/stderr\nstderr_logfile_maxsize=0" /etc/dd-agent/supervisor.conf
+  sed -i -e "/^.*\[program:.*\].*$/a stdout_logfile=\/dev\/stdout\nstdout_logfile_maxbytes=0\nstderr_logfile=\/dev\/stderr\nstderr_logfile_maxbytes=0" /etc/dd-agent/supervisor.conf
 fi
 
 if [[ $DD_URL ]]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -39,6 +39,16 @@ if [[ $LOG_LEVEL ]]; then
     sed -i -e"s/^.*log_level:.*$/log_level: ${LOG_LEVEL}/" /etc/dd-agent/datadog.conf
 fi
 
+if [[ $DD_LOGS_STDOUT ]]; then
+  export LOGS_STDOUT=$DD_LOGS_STDOUT
+fi
+
+if [[ $LOGS_STDOUT == "yes" ]]; then
+  sed -i -e "/^.*_logfile.*$/d" /etc/dd-agent/supervisor.conf
+  sed -i -e "/^.*\[program:.*\].*$/a stdout_logfile=\/dev\/stdout\nstdout_logfile_maxsize=0\nstderr_logfile=\/dev\/stderr\nstderr_logfile_maxsize=0" /etc/dd-agent/supervisor.conf
+  sed -i -e "$ a disable_file_logging: yes" /etc/dd-agent/datadog.conf
+fi
+
 if [[ $DD_URL ]]; then
     sed -i -e 's@^.*dd_url:.*$@dd_url: '${DD_URL}'@' /etc/dd-agent/datadog.conf
 fi


### PR DESCRIPTION
### What does this PR do?

This PR adds the option to send the logs of the agent running in a container to the logs of this container ~~instead of~~ in addition to the agent's log files. It allows for a more direct access of the logs.

This is done by setting the environment variable LOGS_STDOUT to 'yes' when running the docker container with `-e LOGS_STDOUT=yes`.

### Motivation

See this [issue](https://github.com/DataDog/docker-dd-agent/issues/174)

### Additional Notes
Right now, I only managed to test on my local environment by building my own docker image and running the container with the environment variable set to 'yes'. Following the logs of the container, I saw as expected the logs from the forwarder inside. 
~~I haven't tested if these logs were indeed appearing inside of the logs of kubernetes as requested in the [issue](https://github.com/DataDog/docker-dd-agent/issues/174) but I checked [there](https://kubernetes.io/docs/user-guide/docker-cli-to-kubectl/#docker-logs) and it should be ok.~~
Tested and it works.