### PR TITLE
Delete rm '/agent/conf.d/network.yaml.default' in docker files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,14 +20,12 @@ RUN echo "deb http://apt.datadoghq.com/ stable main" > /etc/apt/sources.list.d/d
 # 3. Remove dd-agent user from supervisor configuration
 # 4. Remove dd-agent user from init.d configuration
 # 5. Fix permission on /etc/init.d/datadog-agent
-# 6. Remove network check
 RUN mv /etc/dd-agent/datadog.conf.example /etc/dd-agent/datadog.conf \
  && sed -i -e"s/^.*non_local_traffic:.*$/non_local_traffic: yes/" /etc/dd-agent/datadog.conf \
  && sed -i -e"s/^.*log_to_syslog:.*$/log_to_syslog: no/" /etc/dd-agent/datadog.conf \
  && sed -i "/user=dd-agent/d" /etc/dd-agent/supervisor.conf \
  && sed -i 's/AGENTUSER="dd-agent"/AGENTUSER="root"/g' /etc/init.d/datadog-agent \
- && chmod +x /etc/init.d/datadog-agent \
- && rm /etc/dd-agent/conf.d/network.yaml.default
+ && chmod +x /etc/init.d/datadog-agent
 
 # Add Docker check
 COPY conf.d/docker_daemon.yaml /etc/dd-agent/conf.d/docker_daemon.yaml

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -33,13 +33,11 @@ RUN apk add -qU --no-cache -t .build-deps gcc musl-dev pgcluster-dev linux-heade
 # 1. Listen to statsd from other containers
 # 2. Turn syslog off
 # 3. Remove dd-agent user from supervisor configuration
-# 4. Remove network check
-# 6. Remove setup script
+# 4. Remove setup script
 RUN cp "$DD_HOME/agent/datadog.conf.example" "$DD_HOME/agent/datadog.conf" \
   && sed -i -e"s/^.*non_local_traffic:.*$/non_local_traffic: yes/" "$DD_HOME/agent/datadog.conf" \
   && sed -i -e"s/^.*log_to_syslog:.*$/log_to_syslog: no/" "$DD_HOME/agent/datadog.conf" \
   && sed -i "/user=dd-agent/d" "$DD_HOME/agent/supervisor.conf" \
-  && rm "$DD_HOME/agent/conf.d/network.yaml.default" \
   && rm /tmp/setup_agent.sh
 
 # Healthcheck

--- a/jmx/Dockerfile
+++ b/jmx/Dockerfile
@@ -20,14 +20,12 @@ RUN echo "deb http://apt.datadoghq.com/ stable main" > /etc/apt/sources.list.d/d
 # 3. Remove dd-agent user from supervisor configuration
 # 4. Remove dd-agent user from init.d configuration
 # 5. Fix permission on /etc/init.d/datadog-agent
-# 6. Remove network check
 RUN mv /etc/dd-agent/datadog.conf.example /etc/dd-agent/datadog.conf \
  && sed -i -e"s/^.*non_local_traffic:.*$/non_local_traffic: yes/" /etc/dd-agent/datadog.conf \
  && sed -i -e"s/^.*log_to_syslog:.*$/log_to_syslog: no/" /etc/dd-agent/datadog.conf \
  && sed -i "/user=dd-agent/d" /etc/dd-agent/supervisor.conf \
  && sed -i 's/AGENTUSER="dd-agent"/AGENTUSER="root"/g' /etc/init.d/datadog-agent \
- && chmod +x /etc/init.d/datadog-agent \
- && rm /etc/dd-agent/conf.d/network.yaml.default
+ && chmod +x /etc/init.d/datadog-agent
 
 # Add Docker check
 COPY conf.d/docker_daemon.yaml /etc/dd-agent/conf.d/docker_daemon.yaml


### PR DESCRIPTION
### What does this PR do?
Small fix to make the docker images build. '/agent/conf.d/network.yaml.default' was removed in https://github.com/DataDog/dd-agent/commit/b74d12f63491d4b450ad7927f0b2d04006704d4e so it can't be deleted: 

https://github.com/DataDog/dd-agent/compare/5.11.0...5.12.0

### Motivation

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
