### PR TITLE
We should always use master source installer

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -13,7 +13,7 @@ ENV DD_HOME=/opt/datadog-agent \
 COPY conf.d/docker_daemon.yaml "$DD_HOME/agent/conf.d/docker_daemon.yaml"
 
 # Add install and config files
-ADD https://raw.githubusercontent.com/DataDog/dd-agent/$AGENT_VERSION/packaging/datadog-agent/source/setup_agent.sh /tmp/setup_agent.sh
+ADD https://raw.githubusercontent.com/DataDog/dd-agent/master/packaging/datadog-agent/source/setup_agent.sh /tmp/setup_agent.sh
 COPY entrypoint.sh /entrypoint.sh
 
 # Expose supervisor and DogStatsD port

--- a/dogstatsd/alpine/Dockerfile
+++ b/dogstatsd/alpine/Dockerfile
@@ -9,7 +9,7 @@ ENV DD_HOME=/opt/datadog-agent \
     AGENT_VERSION=5.12.0
 
 # Add install and config files
-ADD https://raw.githubusercontent.com/DataDog/dd-agent/$AGENT_VERSION/packaging/datadog-agent/source/setup_agent.sh /tmp/setup_agent.sh
+ADD https://raw.githubusercontent.com/DataDog/dd-agent/master/packaging/datadog-agent/source/setup_agent.sh /tmp/setup_agent.sh
 COPY entrypoint.sh supervisor.conf /
 
 # Expose supervisor and DogStatsD port


### PR DESCRIPTION
We don't always tag the source install script, so this was only sometimes getting the right one.

AGENT_VERSION can be overridden, as you can see here: https://github.com/DataDog/dd-agent/blob/master/packaging/datadog-agent/source/setup_agent.sh#L48

This means that setting it in the env and then using that in the installer script is preferable to anything else.