### PR TITLE
[jmx] Enable JMX checks for service discovery by default

### DIFF
--- a/jmx/Dockerfile
+++ b/jmx/Dockerfile
@@ -17,12 +17,14 @@ RUN echo "deb http://apt.datadoghq.com/ stable main" > /etc/apt/sources.list.d/d
 # Configure the Agent
 # 1. Listen to statsd from other containers
 # 2. Turn syslog off
-# 3. Remove dd-agent user from supervisor configuration
-# 4. Remove dd-agent user from init.d configuration
-# 5. Fix permission on /etc/init.d/datadog-agent
+# 3. Enable Service Discovery with JMXFetch
+# 4. Remove dd-agent user from supervisor configuration
+# 5. Remove dd-agent user from init.d configuration
+# 6. Fix permission on /etc/init.d/datadog-agent
 RUN mv /etc/dd-agent/datadog.conf.example /etc/dd-agent/datadog.conf \
  && sed -i -e"s/^.*non_local_traffic:.*$/non_local_traffic: yes/" /etc/dd-agent/datadog.conf \
  && sed -i -e"s/^.*log_to_syslog:.*$/log_to_syslog: no/" /etc/dd-agent/datadog.conf \
+ && sed -i -e"s/^.*sd_jmx_enable:.*$/sd_jmx_enable: yes/" /etc/dd-agent/datadog.conf \
  && sed -i "/user=dd-agent/d" /etc/dd-agent/supervisor.conf \
  && sed -i 's/AGENTUSER="dd-agent"/AGENTUSER="root"/g' /etc/init.d/datadog-agent \
  && rm /etc/dd-agent/conf.d/network.yaml.default \


### PR DESCRIPTION
### What does this PR do?

Enables `sd_jmx_enable` by default in the jmx image.

### Motivation

Without this auto config is not enabled with JMXFetch, which kind of defeats the purpose of this image :(

### Testing Guidelines

Checked that the `sed` works as expected
