### PR TITLE
Enable JMX SD with env var

### DIFF
--- a/jmx/entrypoint.sh
+++ b/jmx/entrypoint.sh
@@ -102,6 +102,10 @@ if [[ $SD_CONSUL_TOKEN ]]; then
     sed -i -e 's@^# consul_token:.*$@consul_token: '${SD_CONSUL_TOKEN}'@' /etc/dd-agent/datadog.conf
 fi
 
+if [[ $SD_JMX_ENABLE ]]; then
+    sed -i -e "s/^# sd_jmx_enable:.*$/sd_jmx_enable: ${SD_JMX_ENABLE}/" /etc/dd-agent/datadog.conf
+fi
+
 
 ##### Integrations config #####
 


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*


### What does this PR do?

This permits JMX service discovery via an environment variable, SD_JMX_ENABLE. If set to "yes", the line "# sd_jmx_enable: no" becomes "sd_jmx_enable: yes". If set to "no", it becomes "sd_jmx_enable: no"

### Motivation

JMX SD was not enabled by default in the docker-dd-agent/jmx variant, nor was there a way to enable it at launch (from my quick testing).

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

n/a
