### PR TITLE
Added support for swarm secret & API_KEY_FILE

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,10 +8,14 @@ if [[ $DD_API_KEY ]]; then
   export API_KEY=${DD_API_KEY}
 fi
 
+if [[ $DD_API_KEY_FILE ]]; then
+  export API_KEY=$(cat $DD_API_KEY_FILE)
+fi
+
 if [[ $API_KEY ]]; then
 	sed -i -e "s/^.*api_key:.*$/api_key: ${API_KEY}/" /etc/dd-agent/datadog.conf
 else
-	echo "You must set API_KEY environment variable to run the Datadog Agent container"
+	echo "You must set API_KEY environment variable or include a DD_API_KEY_FILE to run the Datadog Agent container"
 	exit 1
 fi
 


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*


### What does this PR do?

This PR adds support for the use of docker swarm secret handling. 

For context: https://docs.docker.com/engine/swarm/secrets/#build-support-for-docker-secrets-into-your-images

### Motivation

The plan is to use swarm to manage secrets on my current setup. This allows me to do that 👍 