### PR TITLE
[alpine] use tini for pid 1 to allow graceful termination

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -20,7 +20,7 @@ COPY entrypoint.sh /entrypoint.sh
 EXPOSE 9001/tcp 8125/udp
 
 # Install minimal dependencies
-RUN apk add -qU --no-cache coreutils curl curl-dev python-dev tar sysstat
+RUN apk add -qU --no-cache coreutils curl curl-dev python-dev tar sysstat tini
 
 # Install build dependencies
 RUN apk add -qU --no-cache -t .build-deps gcc musl-dev pgcluster-dev linux-headers \
@@ -50,7 +50,7 @@ HEALTHCHECK --interval=5m --timeout=3s --retries=1 \
 # Extra conf.d and checks.d
 VOLUME ["/conf.d", "/checks.d"]
 
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT ["/sbin/tini", "-g", "--", "/entrypoint.sh"]
 
 WORKDIR "$DD_HOME"
 CMD source venv/bin/activate && supervisord -c agent/supervisor.conf


### PR DESCRIPTION
### What does this PR do?

Use tini instead of sh for PID 1 to allow graceful termination of the container.

### Motivation

sh doesn't not pass signals to children. When running in kubernetes terminating a dd-agent container will take as long as the `terminationGracePeriodSeconds` setting which is default of 30s.

tini is commonly used as PID 1 and recommended by the [official images repo](https://github.com/docker-library/official-images#init).

### Additional Notes

Haven't extensively tested for functionality but I'm still getting metrics in my test env. Also confirmed that container termination is much faster in kubernetes and slightly faster locally with docker.
