### PR TITLE
bugfix: KUBERNETES_NAMESPACE_NAME_REGEX

### DIFF
--- a/alpine/entrypoint.sh
+++ b/alpine/entrypoint.sh
@@ -119,7 +119,7 @@ if [[ $KUBERNETES ]]; then
 
         # enable the namespace regex
         if [[ $KUBERNETES_NAMESPACE_NAME_REGEX ]]; then
-            sed -i -e "s@# namespace_name_regexp:@ namespace_name_regexp: ${KUBERNETES_NAMESPACE_NAME_REGEX}" /opt/datadog-agent/agent/conf.d/kubernetes.yaml
+            sed -i -e "s@# namespace_name_regexp:@ namespace_name_regexp: ${KUBERNETES_NAMESPACE_NAME_REGEX}@" /opt/datadog-agent/agent/conf.d/kubernetes.yaml
         fi
     fi
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -137,7 +137,7 @@ if [[ $KUBERNETES ]]; then
 
         # enable the namespace regex
         if [[ $KUBERNETES_NAMESPACE_NAME_REGEX ]]; then
-            sed -i -e "s@# namespace_name_regexp:@ namespace_name_regexp: ${KUBERNETES_NAMESPACE_NAME_REGEX}" /etc/dd-agent/conf.d/kubernetes.yaml
+            sed -i -e "s@# namespace_name_regexp:@ namespace_name_regexp: ${KUBERNETES_NAMESPACE_NAME_REGEX}@" /etc/dd-agent/conf.d/kubernetes.yaml
         fi
     fi
 

--- a/jmx/entrypoint.sh
+++ b/jmx/entrypoint.sh
@@ -124,7 +124,7 @@ if [[ $KUBERNETES ]]; then
 
         # enable the namespace regex
         if [[ $KUBERNETES_NAMESPACE_NAME_REGEX ]]; then
-            sed -i -e "s@# namespace_name_regexp:@ namespace_name_regexp: ${KUBERNETES_NAMESPACE_NAME_REGEX}" /etc/dd-agent/conf.d/kubernetes.yaml
+            sed -i -e "s@# namespace_name_regexp:@ namespace_name_regexp: ${KUBERNETES_NAMESPACE_NAME_REGEX}@" /etc/dd-agent/conf.d/kubernetes.yaml
         fi
     fi
 fi


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*


### What does this PR do?

bugfix: sed handling of KUBERNETES_NAMESPACE_NAME_REGEX

### Motivation

cant reflect KUBERNETES_NAMESPACE_NAME_REGEX to kubernetes.yaml

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes
