### PR TITLE
doc: curb mentions of legacy trace port 7777

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN echo "deb http://apt.datadoghq.com/ stable main" > /etc/apt/sources.list.d/d
  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Configure the Agent
-# 1. Listen to statsd (8125) and traces (8126 and 7777) from other containers
+# 1. Listen to statsd (8125) and traces (8126) from other containers
 # 2. Turn syslog off
 # 3. Remove dd-agent user from supervisor configuration
 # 4. Remove dd-agent user from init.d configuration
@@ -37,7 +37,7 @@ COPY entrypoint.sh /entrypoint.sh
 VOLUME ["/conf.d", "/checks.d"]
 
 # Expose DogStatsD, supervisord and trace-agent ports
-EXPOSE 8125/udp 9001/tcp 8126/tcp 7777/tcp
+EXPOSE 8125/udp 9001/tcp 8126/tcp
 
 # Healthcheck
 HEALTHCHECK --interval=5m --timeout=3s --retries=1 \

--- a/README.md
+++ b/README.md
@@ -168,9 +168,9 @@ Enable the [datadog-trace-agent](https://github.com/DataDog/datadog-trace-agent)
 
 ### Tracing from the host
 
-Tracing can be available on ports 7777/tcp and 8126/tcp from anywhere by adding the options `-p 7777:7777/tcp -p 8126:8126/tcp` to the `docker run` command
+Tracing can be available on port 8126/tcp from anywhere by adding the options `-p 8126:8126/tcp` to the `docker run` command
 
-To make it available from your host only, use `-p 127.0.0.1:7777:7777/tcp -p 127.0.0.1:8126:8126/tcp` instead.
+To make it available from your host only, use `-p 127.0.0.1:8126:8126/tcp` instead.
 
 For example, the following command will allow the agent to receive traces from anywhere
 
@@ -181,13 +181,12 @@ docker run -d --name dd-agent \
   -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
   -e API_KEY={your_api_key_here} \
   -e DD_APM_ENABLED=true \
-  -p 8126:8126/tcp -p 7777:7777/tcp \
+  -p 8126:8126/tcp \
   datadog/docker-dd-agent
 ```
 
-Port 7777 is a legacy port used by former client libraries and is being replaced by 8126.
-For now, it is safer to expose both ports, unless you explicitly configure your
-client to use port 8126. Future client libraries will report to port 8126 by default.
+Previous instructions required binding to port 7777.
+This is a legacy port used by former client libraries and has been replaced by 8126.
 
 ### Tracing from other containers
 As with DogStatsD, traces can be submitted to the agent from other containers either


### PR DESCRIPTION
we're dropping the behavior of binding to the legacy port in https://github.com/DataDog/datadog-trace-agent/pull/271