### PR TITLE
add trace-agent to dogstatsd only container

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ These separate images have the advantage of running DogStatsD server as a non-ro
 
 **Note**: These images run DogStatsD only. In the agent, tags are collected from the configuration file and from labels by the collector which is not running here. Thus those tags will not be associated with any metrics and events processed by this container.
 
+**Note**: Optionally, the standalone DogStatsD image can also run the the trace-agent process. Pass `-e DD_APM_ENABLED=true` to your `docker run` command to activate the trace-agent and allow your container to receive traces from Datadog's APM integrations.
 
 ### DogStatsD from the host
 

--- a/dogstatsd/Dockerfile
+++ b/dogstatsd/Dockerfile
@@ -24,8 +24,8 @@ RUN mv /etc/dd-agent/datadog.conf.example /etc/dd-agent/datadog.conf \
  && sed -i -e"s/^.*log_to_syslog:.*$/log_to_syslog: no/" /etc/dd-agent/datadog.conf \
  && mv /supervisor.conf /etc/dd-agent/supervisor.conf
 
-# Expose supervisor and DogStatsD port
-EXPOSE 9001/tcp 8125/udp
+# Expose supervisor, DogStatsD and trace-agent port
+EXPOSE 9001/tcp 8125/udp 8126/tcp
 
 # Set proper permissions to allow running as a non-root user
 RUN chmod g+w /etc/dd-agent/datadog.conf \

--- a/dogstatsd/entrypoint.sh
+++ b/dogstatsd/entrypoint.sh
@@ -16,6 +16,12 @@ if [[ $DD_URL ]]; then
     sed -i -e 's@^.*dd_url:.*$@dd_url: '${DD_URL}'@' /etc/dd-agent/datadog.conf
 fi
 
+# ensure that the trace-agent doesn't run unless instructed to
+export DD_APM_ENABLED=false
+if [[ $DD_APM_ENABLED ]]; then
+  export DD_APM_ENABLED=${DD_APM_ENABLED}
+fi
+
 export PATH="/opt/datadog-agent/embedded/bin:/opt/datadog-agent/bin:$PATH"
 
 exec "$@"

--- a/dogstatsd/supervisor.conf
+++ b/dogstatsd/supervisor.conf
@@ -42,7 +42,6 @@ stderr_logfile=NONE
 startsecs=5
 startretries=3
 priority=998
-user=dd-agent
 autorestart=unexpected
 exitcodes=0
 

--- a/dogstatsd/supervisor.conf
+++ b/dogstatsd/supervisor.conf
@@ -35,5 +35,16 @@ startsecs=5
 startretries=3
 priority=998
 
+[program:trace-agent]
+command=/opt/datadog-agent/bin/trace-agent
+stdout_logfile=NONE
+stderr_logfile=NONE
+startsecs=5
+startretries=3
+priority=998
+user=dd-agent
+autorestart=unexpected
+exitcodes=0
+
 [group:datadog-agent]
-programs=forwarder,dogstatsd
+programs=forwarder,dogstatsd,trace-agent


### PR DESCRIPTION
This adds the trace-agent program to the dogstatsd supervisor configuration. this allows running the trace-agent as part of the `dogstatsd` only container

When DD_APM_ENABLED=false (the default), the trace-agent will gracefully exit, not affecting the other processes managed by supervisor

should address #199 