### PR TITLE
Environment variable for Rancher custom tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Some configuration parameters can be changed with environment variables:
 * `DD_HOSTNAME` set the hostname (write it in `datadog.conf`)
 * `TAGS` set host tags. Add `-e TAGS=simple-tag-0,tag-key-1:tag-value-1` to use [simple-tag-0, tag-key-1:tag-value-1] as host tags.
 * `EC2_TAGS` set EC2 host tags. Add `-e EC2_TAGS=yes` to use EC2 custom host tags. Requires an [IAM role](https://github.com/DataDog/dd-agent/wiki/Capturing-EC2-tags-at-startup) associated with the instance.
+* `RANCHER_HOST_LABELS` set Rancher host labels as tags. When running in Rancher, add `-e RANCHER_HOST_LABELS=yes` to set host tags based on Rancher labels.
 * `LOG_LEVEL` set logging verbosity (CRITICAL, ERROR, WARNING, INFO, DEBUG). Add `-e LOG_LEVEL=DEBUG` to turn logs to debug mode.
 * `PROXY_HOST`, `PROXY_PORT`, `PROXY_USER` and `PROXY_PASSWORD` set the proxy configuration.
 * `DD_URL` set the Datadog intake server to send Agent data to (used when [using an agent as a proxy](https://github.com/DataDog/dd-agent/wiki/Proxy-Configuration#using-the-agent-as-a-proxy) )

--- a/alpine/entrypoint.sh
+++ b/alpine/entrypoint.sh
@@ -27,6 +27,10 @@ if [[ $EC2_TAGS ]]; then
 	sed -i -e "s/^# collect_ec2_tags.*$/collect_ec2_tags: ${EC2_TAGS}/" /opt/datadog-agent/agent/datadog.conf
 fi
 
+if [[ $RANCHER_HOST_LABELS ]]; then
+	sed -i -e "s/^# collect_rancher_host_labels.*$/collect_rancher_host_labels: ${RANCHER_HOST_LABELS}/" /opt/datadog-agent/agent/datadog.conf
+fi
+
 if [[ $TAGS ]]; then
 	sed -i -r -e "s/^# ?tags:.*$/tags: ${TAGS}/" /opt/datadog-agent/agent/datadog.conf
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,6 +31,10 @@ if [[ $EC2_TAGS ]]; then
 	sed -i -e "s/^# collect_ec2_tags.*$/collect_ec2_tags: ${EC2_TAGS}/" /etc/dd-agent/datadog.conf
 fi
 
+if [[ $RANCHER_HOST_LABELS ]]; then
+	sed -i -e "s/^# collect_rancher_host_labels.*$/collect_rancher_host_labels: ${RANCHER_HOST_LABELS}/" /etc/dd-agent/datadog.conf
+fi
+
 if [[ $TAGS ]]; then
 	sed -i -r -e "s/^# ?tags:.*$/tags: ${TAGS}/" /etc/dd-agent/datadog.conf
 fi

--- a/jmx/entrypoint.sh
+++ b/jmx/entrypoint.sh
@@ -27,6 +27,10 @@ if [[ $EC2_TAGS ]]; then
 	sed -i -e "s/^# collect_ec2_tags.*$/collect_ec2_tags: ${EC2_TAGS}/" /etc/dd-agent/datadog.conf
 fi
 
+if [[ $RANCHER_HOST_LABELS ]]; then
+	sed -i -e "s/^# collect_rancher_host_labels.*$/collect_rancher_host_labels: ${RANCHER_HOST_LABELS}/" /etc/dd-agent/datadog.conf
+fi
+
 if [[ $TAGS ]]; then
 	sed -i -r -e "s/^# ?tags:.*$/tags: ${TAGS}/" /etc/dd-agent/datadog.conf
 fi


### PR DESCRIPTION
### What does this PR do?

- Offers the ability to set `-e RANCHER_HOST_LABELS=yes` when running `docker-dd-agent`.  This adds `check_rancher_host_labels` to the `datadog.conf` file to enable the collection of host labels from the Rancher API (when running in a Rancher cluster) which are then added to the host as tags in Datadog.  This feature is currently in PR here: https://github.com/DataDog/dd-agent/pull/3366

### Motivation

Considering the work in this PR of dd-agent: https://github.com/DataDog/dd-agent/pull/3366 it made sense to update `docker-dd-agent` so this configuration option can be easily enabled when deploying the Datadog agent as a service in Rancher.

Please see the main PR for a full description of the motivation behind this work.

### Additional Notes

This PR depends on this one: https://github.com/DataDog/dd-agent/pull/3366
