### PR TITLE
add SD_JMX_ENABLE and USE_DOGSTATSD env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Some configuration parameters can be changed with environment variables:
    - `SD_CONFIG_BACKEND` can be set to `etcd` or `consul` which are the two configuration stores we support at the moment.
    - `SD_BACKEND_HOST` and `SD_BACKEND_PORT` are used to configure the connection to the configuration store, and `SD_TEMPLATE_DIR` to specify the path where the check configuration templates are stored.
    - `SD_CONSUL_TOKEN` is used to provide an authentication token for the agent to connect to Consul if required.
+   - `SD_JMX_ENABLE` can be set to `yes` to enble JMX service discovery
 * `DD_APM_ENABLED` run the trace-agent along with the infrastructure agent, allowing the container to accept traces on 8126/tcp (**This option is NOT available on Alpine Images**)
 
 **Note:** it is possible to use `DD_TAGS` instead of `TAGS`, `DD_LOG_LEVEL` instead of `LOG_LEVEL` and `DD_API_KEY` instead of `API_KEY`, these variables have the same impact.
@@ -137,6 +138,9 @@ DogStatsD can be available on port 8125 from anywhere by adding the option `-p 8
 
 To make it available from your host only, use `-p 127.0.0.1:8125:8125/udp` instead.
 
+### Disable dogstatsd
+
+DogStatsd can be disabled by setting `USE_DOGSTATSD` to `no`
 
 ### DogStatsD from other containers
 

--- a/alpine/entrypoint.sh
+++ b/alpine/entrypoint.sh
@@ -47,6 +47,10 @@ if [[ $STATSD_METRIC_NAMESPACE ]]; then
     sed -i -e "s/^# statsd_metric_namespace:.*$/statsd_metric_namespace: ${STATSD_METRIC_NAMESPACE}/" /opt/datadog-agent/agent/datadog.conf
 fi
 
+if [[ $USE_DOGSTATSD ]]; then
+    sed -i -e "s/^.*use_dogstatsd:.*$/use_dogstatsd: ${USE_DOGSTATSD}/" /opt/datadog-agent/agent/datadog.conf
+fi
+
 
 ##### Proxy config #####
 
@@ -97,6 +101,9 @@ if [[ $SD_CONSUL_TOKEN ]]; then
     sed -i -e 's@^# consul_token:.*$@consul_token: '${SD_CONSUL_TOKEN}'@' /opt/datadog-agent/agent/datadog.conf
 fi
 
+if [[ $SD_JMX_ENABLE ]]; then
+    sed -i -e "s/^.*sd_jmx_enable:.*$/sd_jmx_enable: ${SD_JMX_ENABLE}/" /opt/datadog-agent/agent/datadog.conf
+fi
 
 ##### Integrations config #####
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -64,6 +64,10 @@ if [[ $STATSD_METRIC_NAMESPACE ]]; then
     sed -i -e "s/^# statsd_metric_namespace:.*$/statsd_metric_namespace: ${STATSD_METRIC_NAMESPACE}/" /etc/dd-agent/datadog.conf
 fi
 
+if [[ $USE_DOGSTATSD ]]; then
+    sed -i -e "s/^.*use_dogstatsd:.*$/use_dogstatsd: ${USE_DOGSTATSD}/" /etc/dd-agent/datadog.conf
+fi
+
 
 ##### Proxy config #####
 
@@ -115,6 +119,9 @@ if [[ $SD_CONSUL_TOKEN ]]; then
     sed -i -e 's@^# consul_token:.*$@consul_token: '${SD_CONSUL_TOKEN}'@' /etc/dd-agent/datadog.conf
 fi
 
+if [[ $SD_JMX_ENABLE ]]; then
+    sed -i -e "s/^.*sd_jmx_enable:.*$/sd_jmx_enable: ${SD_JMX_ENABLE}/" /etc/dd-agent/datadog.conf
+fi
 
 ##### Integrations config #####
 

--- a/jmx/entrypoint.sh
+++ b/jmx/entrypoint.sh
@@ -51,6 +51,10 @@ if [[ $STATSD_METRIC_NAMESPACE ]]; then
     sed -i -e "s/^# statsd_metric_namespace:.*$/statsd_metric_namespace: ${STATSD_METRIC_NAMESPACE}/" /etc/dd-agent/datadog.conf
 fi
 
+if [[ $USE_DOGSTATSD ]]; then
+    sed -i -e "s/^.*use_dogstatsd:.*$/use_dogstatsd: ${USE_DOGSTATSD}/" /etc/dd-agent/datadog.conf
+fi
+
 
 ##### Proxy config #####
 


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*


### What does this PR do?

add SD_JMX_ENABLE and USE_DOGSTATSD env vars

### Motivation

Allows enabling of JMX service discovery and disabling of dogstatsd service.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
