### PR TITLE
install openjdk for jmx in alpine image

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -20,7 +20,7 @@ COPY entrypoint.sh /entrypoint.sh
 EXPOSE 9001/tcp 8125/udp
 
 # Install minimal dependencies
-RUN apk add -qU --no-cache coreutils curl curl-dev python-dev tar sysstat tini
+RUN apk add -qU --no-cache coreutils curl curl-dev python-dev tar sysstat tini openjdk7-jre
 
 # Install build dependencies
 RUN apk add -qU --no-cache -t .build-deps gcc musl-dev pgcluster-dev linux-headers \


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*


### What does this PR do?

Add openjdk to list of packages to install on Alpine.

### Motivation

jmxfetch requires openjdk.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
