### PR TITLE
allow slashes in TAGS/ECS2_TAGS vars by escaping them

### DIFF
--- a/alpine/entrypoint.sh
+++ b/alpine/entrypoint.sh
@@ -28,10 +28,12 @@ if [[ $DD_TAGS ]]; then
 fi
 
 if [[ $EC2_TAGS ]]; then
+	export EC2_TAGS=${EC2_TAGS//\//\\/}  # escape forward slashes from tags before invoking sed
 	sed -i -e "s/^# collect_ec2_tags.*$/collect_ec2_tags: ${EC2_TAGS}/" /opt/datadog-agent/agent/datadog.conf
 fi
 
 if [[ $TAGS ]]; then
+	export TAGS=${TAGS//\//\\/}  # escape forward slashes from tags before invoking sed
 	sed -i -r -e "s/^# ?tags:.*$/tags: ${TAGS}/" /opt/datadog-agent/agent/datadog.conf
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -28,10 +28,12 @@ if [[ $DD_TAGS ]]; then
 fi
 
 if [[ $EC2_TAGS ]]; then
+	export EC2_TAGS=${EC2_TAGS//\//\\/}  # escape forward slashes from tags before invoking sed
 	sed -i -e "s/^# collect_ec2_tags.*$/collect_ec2_tags: ${EC2_TAGS}/" /etc/dd-agent/datadog.conf
 fi
 
 if [[ $TAGS ]]; then
+	export TAGS=${TAGS//\//\\/}  # escape forward slashes from tags before invoking sed
 	sed -i -r -e "s/^# ?tags:.*$/tags: ${TAGS}/" /etc/dd-agent/datadog.conf
 fi
 

--- a/jmx/entrypoint.sh
+++ b/jmx/entrypoint.sh
@@ -28,10 +28,12 @@ if [[ $DD_TAGS ]]; then
 fi
 
 if [[ $EC2_TAGS ]]; then
+	export EC2_TAGS=${EC2_TAGS//\//\\/}  # escape forward slashes from tags before invoking sed
 	sed -i -e "s/^# collect_ec2_tags.*$/collect_ec2_tags: ${EC2_TAGS}/" /etc/dd-agent/datadog.conf
 fi
 
 if [[ $TAGS ]]; then
+	export TAGS=${TAGS//\//\\/}  # escape forward slashes from tags before invoking sed
 	sed -i -r -e "s/^# ?tags:.*$/tags: ${TAGS}/" /etc/dd-agent/datadog.conf
 fi
 


### PR DESCRIPTION
As we inject them with sed with a / delimiter, slashes in tag values led to syntax errors. 
Instead of changing the sed delimiter and risking having the bug on another
character, I used bash parameter expansion to escape them with a \ before sed-ing

See https://www.gnu.org/software/bash/manual/bashref.html#Shell-Parameter-Expansion

### Motivation

Support case