### PR TITLE
Make sure checks.d directory is present

### DIFF
--- a/alpine/entrypoint.sh
+++ b/alpine/entrypoint.sh
@@ -156,6 +156,7 @@ fi
 
 find /conf.d -name '*.yaml' -exec cp --parents {} /opt/datadog-agent/agent \;
 
+mkdir -p /opt/datadog-agent/agent/checks.d
 find /checks.d -name '*.py' -exec cp {} /opt/datadog-agent/agent/checks.d \;
 
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -171,6 +171,7 @@ fi
 
 find /conf.d -name '*.yaml' -exec cp --parents {} /etc/dd-agent \;
 
+mkdir -p /etc/dd-agent/checks.d
 find /checks.d -name '*.py' -exec cp {} /etc/dd-agent/checks.d \;
 
 


### PR DESCRIPTION
### What does this PR do?

It makes sure the checks.d directory is present in the container.

### Motivation

Otherwise the following copy command will create a file called 'checks.d' for the first check file.

We weren't previously able to mount a checks.d directory as a volume. The mounting-as-a-volume part worked, but the copying-to-the-actual-directory part was broken because the target checks.d directory within the container didn't exist.