### PR TITLE
add KUBERNETES_COLLECT_SERVICE_TAGS envvar for kubernetes' collect_service_tags conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Some configuration parameters can be changed with environment variables:
 It is possible to enable some checks through the environment:
 
 * `KUBERNETES` enables the kubernetes check if set (`KUBERNETES=yes` works). `KUBERNETES_COLLECT_EVENTS` enables event collection from the kubernetes API, given that `KUBERNETES` is also set. **Note:** only one agent should have `KUBERNETES_COLLECT_EVENTS` set per cluster.
+* to collect the `kube_service` tags, the agent needs to query the apiserver's events and services endpoints. If you need to disable that, you can pass `KUBERNETES_COLLECT_SERVICE_TAGS=false`.
 * the kubelet API endpoint is assumed to be the default route of the container, you can override the kubelet API endpoint by specifying `KUBERNETES_KUBELET_HOST` (eg. when using CNI networking, the kubelet API may not listen on the default route address)
 * `MESOS_MASTER` and `MESOS_SLAVE` respectively enable the mesos master and mesos slave checks if set (`MESOS_MASTER=yes` works).
 * `MARATHON_URL` if set will be used to enable the Marathon check that will query the URL passed in this variable for metrics. It can usually be set to `http://leader.mesos:8080`.

--- a/alpine/entrypoint.sh
+++ b/alpine/entrypoint.sh
@@ -125,6 +125,11 @@ if [[ $KUBERNETES ]]; then
     # enable kubernetes check
     cp /opt/datadog-agent/agent/conf.d/kubernetes.yaml.example /opt/datadog-agent/agent/conf.d/kubernetes.yaml
 
+    # allows to disable kube_service tagging if needed (big clusters)
+    if [[ $KUBERNETES_COLLECT_SERVICE_TAGS ]]; then
+        sed -i -e 's@# collect_service_tags:.*$@ collect_service_tags: '${KUBERNETES_COLLECT_SERVICE_TAGS}'@' /opt/datadog-agent/agent/conf.d/kubernetes.yaml
+    fi
+
     # enable event collector
     # WARNING: to avoid duplicates, only one agent at a time across the entire cluster should have this feature enabled.
     if [[ $KUBERNETES_COLLECT_EVENTS ]]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -139,6 +139,11 @@ if [[ $KUBERNETES ]]; then
     # enable kubernetes check
     cp /etc/dd-agent/conf.d/kubernetes.yaml.example /etc/dd-agent/conf.d/kubernetes.yaml
 
+    # allows to disable kube_service tagging if needed (big clusters)
+    if [[ $KUBERNETES_COLLECT_SERVICE_TAGS ]]; then
+        sed -i -e 's@# collect_service_tags:.*$@ collect_service_tags: '${KUBERNETES_COLLECT_SERVICE_TAGS}'@' /etc/dd-agent/conf.d/kubernetes.yaml
+    fi
+
     # enable event collector
     # WARNING: to avoid duplicates, only one agent at a time across the entire cluster should have this feature enabled.
     if [[ $KUBERNETES_COLLECT_EVENTS ]]; then

--- a/jmx/entrypoint.sh
+++ b/jmx/entrypoint.sh
@@ -126,6 +126,11 @@ fi
 if [[ $KUBERNETES ]]; then
     # enable kubernetes check
     cp /etc/dd-agent/conf.d/kubernetes.yaml.example /etc/dd-agent/conf.d/kubernetes.yaml
+    
+    # allows to disable kube_service tagging if needed (big clusters)
+    if [[ $KUBERNETES_COLLECT_SERVICE_TAGS ]]; then
+        sed -i -e 's@# collect_service_tags:.*$@ collect_service_tags: '${KUBERNETES_COLLECT_SERVICE_TAGS}'@' /etc/dd-agent/conf.d/kubernetes.yaml
+    fi
 
     # enable event collector
     # WARNING: to avoid duplicates, only one agent at a time across the entire cluster should have this feature enabled.


### PR DESCRIPTION
### What does this PR do?

As a follow-up for https://github.com/DataDog/integrations-core/pull/476 and sister PR, allow to disable `kube_service` tagging with an envvar.

All three entrypoints are patched.