### PR TITLE
add SD_BACKEND_USER and SD_BACKEND_PASSWORD envvar bindinds for 5.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,14 +63,16 @@ Some configuration parameters can be changed with environment variables:
 * `DD_URL` set the Datadog intake server to send Agent data to (used when [using an agent as a proxy](https://github.com/DataDog/dd-agent/wiki/Proxy-Configuration#using-the-agent-as-a-proxy) )
 * `NON_LOCAL_TRAFFIC` tells the image to set the `non_local_traffic: true` option, which enables statsd reporting from any external ip. You may find this useful to report metrics from your other containers. See [network configuration](https://github.com/DataDog/dd-agent/wiki/Network-Traffic-and-Proxy-Configuration) for more details.
 * ~~`DOGSTATSD_ONLY` tell the image to only start a standalone dogstatsd instance.~~ **[deprecated]: please use [the dogstatsd-only image](#standalone-dogstatsd)**
-* `SD_BACKEND`, `SD_CONFIG_BACKEND`, `SD_BACKEND_HOST`, `SD_BACKEND_PORT`, `SD_TEMPLATE_DIR` and `SD_CONSUL_TOKEN` configure Autodiscovery (previously known as Service Discovery):
+* `SD_BACKEND`, `SD_CONFIG_BACKEND`, `SD_BACKEND_HOST`, `SD_BACKEND_PORT`, `SD_TEMPLATE_DIR`, `SD_CONSUL_TOKEN`, `SD_BACKEND_USER` and `SD_BACKEND_PASSWORD` configure Autodiscovery (previously known as Service Discovery):
 
    - `SD_BACKEND`: set to `docker` (the only supported backend) to enable Autodiscovery.
    - `SD_CONFIG_BACKEND`: set to `etcd`, `consul`, or `zookeeper` to use one of these key-value stores as a template source.
    - `SD_BACKEND_HOST` and `SD_BACKEND_PORT`: configure the connection to the key-value template source.
    - `SD_TEMPLATE_DIR`: when using SD_CONFIG_BACKEND, set the path where the check configuration templates are located in the key-value store (default is `datadog/check_configs`)
    - `SD_CONSUL_TOKEN`: when using Consul as a template source and the Consul cluster requires authentication, set a token so the Datadog Agent can connect.
+   - `SD_BACKEND_USER` and `SD_BACKEND_PASSWORD`: when using etcd as a template source and it requires authentication, set a user and password so the Datadog Agent can connect.
    - `SD_JMX_ENABLE`: set to `yes` to enable Autodiscovery for JMX-based checks. **Use with `docker-dd-agent:latest-jmx`; this image includes a JVM, which is needed to run jmxfetch.**
+
 * `DD_APM_ENABLED` run the trace-agent along with the infrastructure agent, allowing the container to accept traces on 8126/tcp (**This option is NOT available on Alpine Images**)
 
 **Note:** it is possible to use `DD_TAGS` instead of `TAGS`, `DD_LOG_LEVEL` instead of `LOG_LEVEL` and `DD_API_KEY` instead of `API_KEY`, these variables have the same impact.

--- a/alpine/entrypoint.sh
+++ b/alpine/entrypoint.sh
@@ -107,6 +107,14 @@ if [[ $SD_CONSUL_TOKEN ]]; then
     sed -i -e 's@^# consul_token:.*$@consul_token: '${SD_CONSUL_TOKEN}'@' /opt/datadog-agent/agent/datadog.conf
 fi
 
+if [[ $SD_BACKEND_USER ]]; then
+    sed -i -e 's@^# sd_backend_username:.*$@sd_backend_username: '${SD_BACKEND_USER}'@' /opt/datadog-agent/agent/datadog.conf
+fi
+
+if [[ $SD_BACKEND_PASSWORD ]]; then
+    sed -i -e 's@^# sd_backend_password:.*$@sd_backend_password: '${SD_BACKEND_PASSWORD}'@' /opt/datadog-agent/agent/datadog.conf
+fi
+
 if [[ $SD_JMX_ENABLE ]]; then
     sed -i -e "s/^.*sd_jmx_enable:.*$/sd_jmx_enable: ${SD_JMX_ENABLE}/" /opt/datadog-agent/agent/datadog.conf
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -121,6 +121,14 @@ if [[ $SD_CONSUL_TOKEN ]]; then
     sed -i -e 's@^# consul_token:.*$@consul_token: '${SD_CONSUL_TOKEN}'@' /etc/dd-agent/datadog.conf
 fi
 
+if [[ $SD_BACKEND_USER ]]; then
+    sed -i -e 's@^# sd_backend_username:.*$@sd_backend_username: '${SD_BACKEND_USER}'@' /etc/dd-agent/datadog.conf
+fi
+
+if [[ $SD_BACKEND_PASSWORD ]]; then
+    sed -i -e 's@^# sd_backend_password:.*$@sd_backend_password: '${SD_BACKEND_PASSWORD}'@' /etc/dd-agent/datadog.conf
+fi
+
 if [[ $SD_JMX_ENABLE ]]; then
     sed -i -e "s/^.*sd_jmx_enable:.*$/sd_jmx_enable: ${SD_JMX_ENABLE}/" /etc/dd-agent/datadog.conf
 fi

--- a/jmx/entrypoint.sh
+++ b/jmx/entrypoint.sh
@@ -112,6 +112,13 @@ if [[ $SD_CONSUL_TOKEN ]]; then
     sed -i -e 's@^# consul_token:.*$@consul_token: '${SD_CONSUL_TOKEN}'@' /etc/dd-agent/datadog.conf
 fi
 
+if [[ $SD_BACKEND_USER ]]; then
+    sed -i -e 's@^# sd_backend_username:.*$@sd_backend_username: '${SD_BACKEND_USER}'@' /etc/dd-agent/datadog.conf
+fi
+
+if [[ $SD_BACKEND_PASSWORD ]]; then
+    sed -i -e 's@^# sd_backend_password:.*$@sd_backend_password: '${SD_BACKEND_PASSWORD}'@' /etc/dd-agent/datadog.conf
+fi
 
 ##### Integrations config #####
 


### PR DESCRIPTION
### What does this PR do?

5.15 introduces the `sd_backend_username` and `sd_backend_password` options (for etcd only for now). This PR introduces envvar bindings to set them.

Users that don't want to send credentials as envvars can create a custom image shipping their own `datadog.conf` file.