### PR TITLE
Log to STDOUT/STDERR in Alpine container when LOGS_STDOUT is set

### DIFF
--- a/alpine/entrypoint.sh
+++ b/alpine/entrypoint.sh
@@ -45,6 +45,18 @@ if [[ $LOG_LEVEL ]]; then
     sed -i -e"s/^.*log_level:.*$/log_level: ${LOG_LEVEL}/" /opt/datadog-agent/agent/datadog.conf
 fi
 
+if [[ $DD_LOGS_STDOUT ]]; then
+  export LOGS_STDOUT=$DD_LOGS_STDOUT
+fi
+
+if [[ $LOGS_STDOUT == "yes" ]]; then
+  sed -i -e "/^.*_logfile.*$/d" /opt/datadog-agent/agent/supervisor.conf
+  sed -i -e "/^.*\[program:.*\].*$/a stdout_logfile=\/dev\/stdout" /opt/datadog-agent/agent/supervisor.conf
+  sed -i -e "/^.*\[program:.*\].*$/a stdout_logfile_maxbytes=0" /opt/datadog-agent/agent/supervisor.conf
+  sed -i -e "/^.*\[program:.*\].*$/a stderr_logfile=\/dev\/stderr" /opt/datadog-agent/agent/supervisor.conf
+  sed -i -e "/^.*\[program:.*\].*$/a stderr_logfile_maxbytes=0" /opt/datadog-agent/agent/supervisor.conf
+fi
+
 if [[ $DD_URL ]]; then
     sed -i -e 's@^.*dd_url:.*$@dd_url: '${DD_URL}'@' /opt/datadog-agent/agent/datadog.conf
 fi


### PR DESCRIPTION
### What does this PR do?

This PR lets you set either the `LOGS_STDOUT` or `DD_LOGS_STDOUT` env var to `yes` to force the agent's components to log to stdout and stderr, in addition to its normal log file.

This brings STDOUT logging in the Alpine image into feature parity with
the Debian image.

This feature was implemented in the Debian image in https://github.com/DataDog/docker-dd-agent/pull/176.

### Motivation

Running the Alpine docker-dd-agent in Kubernetes it is _much_ easier to access its logs if they go to STDOUT and STDERR.

### Additional Notes

I've tested this locally by running the container with `-e LOGS_STDOUT=yes` and have seen it work.
