### PR TITLE
add DD_LOGS_STDOUT handling to jmx variant + documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Some configuration parameters can be changed with environment variables:
 * `TAGS` set host tags. Add `-e TAGS=simple-tag-0,tag-key-1:tag-value-1` to use [simple-tag-0, tag-key-1:tag-value-1] as host tags.
 * `EC2_TAGS` set EC2 host tags. Add `-e EC2_TAGS=yes` to use EC2 custom host tags. Requires an [IAM role](https://github.com/DataDog/dd-agent/wiki/Capturing-EC2-tags-at-startup) associated with the instance.
 * `LOG_LEVEL` set logging verbosity (CRITICAL, ERROR, WARNING, INFO, DEBUG). Add `-e LOG_LEVEL=DEBUG` to turn logs to debug mode.
+* `DD_LOGS_STDOUT` sends all logs to stdout and stderr, for them to be processed by Docker.
 * `PROXY_HOST`, `PROXY_PORT`, `PROXY_USER` and `PROXY_PASSWORD` set the proxy configuration.
 * `DD_URL` set the Datadog intake server to send Agent data to (used when [using an agent as a proxy](https://github.com/DataDog/dd-agent/wiki/Proxy-Configuration#using-the-agent-as-a-proxy) )
 * `NON_LOCAL_TRAFFIC` tells the image to set the `non_local_traffic: true` option, which enables statsd reporting from any external ip. You may find this useful to report metrics from your other containers. See [network configuration](https://github.com/DataDog/dd-agent/wiki/Network-Traffic-and-Proxy-Configuration) for more details.

--- a/jmx/entrypoint.sh
+++ b/jmx/entrypoint.sh
@@ -45,6 +45,18 @@ if [[ $LOG_LEVEL ]]; then
     sed -i -e"s/^.*log_level:.*$/log_level: ${LOG_LEVEL}/" /etc/dd-agent/datadog.conf
 fi
 
+if [[ $DD_LOGS_STDOUT ]]; then
+  export LOGS_STDOUT=$DD_LOGS_STDOUT
+fi
+
+if [[ $LOGS_STDOUT == "yes" ]]; then
+  sed -i -e "/^.*_logfile.*$/d" /etc/dd-agent/supervisor.conf
+  sed -i -e "/^.*\[program:.*\].*$/a stdout_logfile=\/dev\/stdout" /etc/dd-agent/supervisor.conf
+  sed -i -e "/^.*\[program:.*\].*$/a stdout_logfile_maxbytes=0" /etc/dd-agent/supervisor.conf
+  sed -i -e "/^.*\[program:.*\].*$/a stderr_logfile=\/dev\/stderr" /etc/dd-agent/supervisor.conf
+  sed -i -e "/^.*\[program:.*\].*$/a stderr_logfile_maxbytes=0" /etc/dd-agent/supervisor.conf
+fi
+
 if [[ $DD_URL ]]; then
     sed -i -e 's@^.*dd_url:.*$@dd_url: '${DD_URL}'@' /etc/dd-agent/datadog.conf
 fi


### PR DESCRIPTION
### What does this PR do?

Mirroring #176 and #220, adds handling of the `DD_LOGS_STDOUT` envvar for the jmx variant. As that envvar was not documented, updated the README too.
