### PR TITLE
Fix "x509: failed to load system roots and no roots provided"

### DIFF
--- a/dogstatsd/Dockerfile
+++ b/dogstatsd/Dockerfile
@@ -11,7 +11,7 @@ COPY entrypoint.sh supervisor.conf /
 RUN echo "deb http://apt.datadoghq.com/ stable main" > /etc/apt/sources.list.d/datadog.list \
  && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C7A7DA52 \
  && apt-get update \
- && apt-get install --no-install-recommends -y datadog-agent="${AGENT_VERSION}" \
+ && apt-get install --no-install-recommends -y datadog-agent="${AGENT_VERSION}" ca-certificates \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/dogstatsd/alpine/Dockerfile
+++ b/dogstatsd/alpine/Dockerfile
@@ -16,7 +16,7 @@ COPY entrypoint.sh supervisor.conf /
 EXPOSE 9001/tcp 8125/udp
 
 # Install minimal dependencies
-RUN apk add -qU --no-cache curl-dev python-dev tar sysstat
+RUN apk add -qU --no-cache curl-dev python-dev tar sysstat ca-certificates
 
 # Install build dependencies
 RUN apk add -qU --no-cache -t .build-deps curl gcc musl-dev pgcluster-dev linux-headers \


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*


### What does this PR do?

Tracer agent is using HTTPS connection to Datadog services to push payload, but when ca-certificates package is not installed then it fails during flush giving error as in title. This PR fixes that and allows to push the payload properly

### Motivation

I am playing with APM and found that issue, since it's a quick fix I decided to do a PR

