### PR TITLE
add DD_HOSTNAME envvar binding to both dsd flavours

### DIFF
--- a/dogstatsd/alpine/entrypoint.sh
+++ b/dogstatsd/alpine/entrypoint.sh
@@ -20,6 +20,10 @@ if [[ $DD_URL ]]; then
     sed -i -e 's@^.*dd_url:.*$@dd_url: '${DD_URL}'@' $DD_HOME/agent/datadog.conf
 fi
 
+if [[ $DD_HOSTNAME ]]; then
+    sed -i -r -e "s/^# ?hostname.*$/hostname: ${DD_HOSTNAME}/" $DD_HOME/agent/datadog.conf
+fi
+
 export PATH="$DD_HOME/venv/bin:$DD_HOME/bin:$PATH"
 
 exec "$@"

--- a/dogstatsd/entrypoint.sh
+++ b/dogstatsd/entrypoint.sh
@@ -20,6 +20,10 @@ if [[ $DD_URL ]]; then
     sed -i -e 's@^.*dd_url:.*$@dd_url: '${DD_URL}'@' /etc/dd-agent/datadog.conf
 fi
 
+if [[ $DD_HOSTNAME ]]; then
+    sed -i -r -e "s/^# ?hostname.*$/hostname: ${DD_HOSTNAME}/" /etc/dd-agent/datadog.conf
+fi
+
 # ensure that the trace-agent doesn't run unless instructed to
 if [[ $DD_APM_ENABLED ]]; then
     export DD_APM_ENABLED=${DD_APM_ENABLED}


### PR DESCRIPTION
Add `DD_HOSTNAME` envvar binding to both dsd flavours, as is it is the case with full agent images.

Fixes https://github.com/DataDog/docker-dd-agent/issues/221