### PR TITLE
Do not set -x on entrypoint - it emits the api tokens into logs.

### DIFF
--- a/alpine/entrypoint.sh
+++ b/alpine/entrypoint.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 #set -e
-set -x
 
 ##### Core config #####
 


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*


### What does this PR do?

Mitigates a data leak in the alpine docker build caused by enabling xtrace in the entrypoint

### Motivation

Found API tokens in our logstream from this app, figured noone else should suffer the revoke-recreate cycle we're about to :-) 

### Testing Guidelines

1. Run the alpine container
2. Expect to not see bash -x output like the below

+ export API_KEY=<ELIDED>
+ [[ <ELIDED> 0]]
+ sed -i -e s/^.*api_key:.*$/api_key: <ELIDED>/ /opt/datadog-agent/agent/datadog.conf


### Additional Notes


