### PR TITLE
envvar bindinds for k8s leader election

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ It is possible to enable some checks through the environment:
 
 * `KUBERNETES` enables the kubernetes check if set (`KUBERNETES=yes` works)
 * to collect the kubernetes events, you can set `KUBERNETES_COLLECT_EVENTS` to `true` on **one agent per cluster**. Alternatively, you can enable the leader election mechanism by setting `KUBERNETES_LEADER_CANDIDATE` to `true` on candidate agents, and adjust the lease time (in seconds) with the `KUBERNETES_LEADER_LEASE_DURATION` variable.
+* by default, only events from the `default` namespace are collected. To change what namespaces are used, set the `KUBERNETES_NAMESPACE_NAME_REGEX` regexp to a valid regexp matching your relevant namespaces.
 * to collect the `kube_service` tags, the agent needs to query the apiserver's events and services endpoints. If you need to disable that, you can pass `KUBERNETES_COLLECT_SERVICE_TAGS=false`.
 * the kubelet API endpoint is assumed to be the default route of the container, you can override the kubelet API endpoint by specifying `KUBERNETES_KUBELET_HOST` (eg. when using CNI networking, the kubelet API may not listen on the default route address)
 * `MESOS_MASTER` and `MESOS_SLAVE` respectively enable the mesos master and mesos slave checks if set (`MESOS_MASTER=yes` works).

--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ Some configuration parameters can be changed with environment variables:
 
 It is possible to enable some checks through the environment:
 
-* `KUBERNETES` enables the kubernetes check if set (`KUBERNETES=yes` works). `KUBERNETES_COLLECT_EVENTS` enables event collection from the kubernetes API, given that `KUBERNETES` is also set. **Note:** only one agent should have `KUBERNETES_COLLECT_EVENTS` set per cluster.
+* `KUBERNETES` enables the kubernetes check if set (`KUBERNETES=yes` works)
+* to collect the kubernetes events, you can set `KUBERNETES_COLLECT_EVENTS` to `true` on **one agent per cluster**. Alternatively, you can enable the leader election mechanism by setting `KUBERNETES_LEADER_CANDIDATE` to `true` on candidate agents, and adjust the lease time (in seconds) with the `KUBERNETES_LEADER_LEASE_DURATION` variable.
 * to collect the `kube_service` tags, the agent needs to query the apiserver's events and services endpoints. If you need to disable that, you can pass `KUBERNETES_COLLECT_SERVICE_TAGS=false`.
 * the kubelet API endpoint is assumed to be the default route of the container, you can override the kubelet API endpoint by specifying `KUBERNETES_KUBELET_HOST` (eg. when using CNI networking, the kubelet API may not listen on the default route address)
 * `MESOS_MASTER` and `MESOS_SLAVE` respectively enable the mesos master and mesos slave checks if set (`MESOS_MASTER=yes` works).

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -43,6 +43,16 @@ if [ $KUBERNETES ]; then
     sed -i -e 's@# collect_service_tags:.*$@ collect_service_tags: '${KUBERNETES_COLLECT_SERVICE_TAGS}'@' ${DD_ETC_ROOT}/conf.d/kubernetes.yaml
   fi
 
+  # enable leader election mechanism for event collection
+  if [ $KUBERNETES_LEADER_CANDIDATE ]; then
+    sed -i -e 's@# leader_candidate:.*$@ leader_candidate: '${KUBERNETES_LEADER_CANDIDATE}'@' ${DD_ETC_ROOT}/conf.d/kubernetes.yaml
+
+    # set the lease time for leader election
+    if [ $KUBERNETES_LEADER_LEASE_DURATION ]; then
+      sed -i -e "s@# leader_lease_duration:.*@ leader_lease_duration: ${KUBERNETES_LEADER_LEASE_DURATION}@" ${DD_ETC_ROOT}/conf.d/kubernetes.yaml
+    fi
+  fi
+
   # enable event collector
   # WARNING: to avoid duplicates, only one agent at a time across the entire cluster should have this feature enabled.
   if [ $KUBERNETES_COLLECT_EVENTS ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -57,11 +57,11 @@ if [ $KUBERNETES ]; then
   # WARNING: to avoid duplicates, only one agent at a time across the entire cluster should have this feature enabled.
   if [ $KUBERNETES_COLLECT_EVENTS ]; then
     sed -i -e "s@# collect_events: false@ collect_events: true@" ${DD_ETC_ROOT}/conf.d/kubernetes.yaml
+  fi
 
-    # enable the namespace regex
-    if [ $KUBERNETES_NAMESPACE_NAME_REGEX ]; then
-      sed -i -e "s@# namespace_name_regexp:@ namespace_name_regexp: ${KUBERNETES_NAMESPACE_NAME_REGEX}@" ${DD_ETC_ROOT}/conf.d/kubernetes.yaml
-    fi
+  # enable the namespace regex
+  if [ $KUBERNETES_NAMESPACE_NAME_REGEX ]; then
+    sed -i -e "s@# namespace_name_regexp:@ namespace_name_regexp: ${KUBERNETES_NAMESPACE_NAME_REGEX}@" ${DD_ETC_ROOT}/conf.d/kubernetes.yaml
   fi
 
 fi


### PR DESCRIPTION
### What does this PR do?

Add `KUBERNETES_LEADER_CANDIDATE` and `KUBERNETES_LEADER_LEASE_DURATION` envvar bindings to entrypoint for 5.17 leader election feature. Update README

### Testing Guidelines

Tag `xvello_beta` is being rebuilt with that commit cherry-picked
