### PR TITLE
Fix sd_config_backend and sd_backend_host vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Some configuration parameters can be changed with environment variables:
 * `SD_BACKEND`, `SD_CONFIG_BACKEND`, `SD_BACKEND_HOST`, `SD_BACKEND_PORT`, `SD_TEMPLATE_DIR`, `SD_CONSUL_TOKEN`, `SD_BACKEND_USER` and `SD_BACKEND_PASSWORD` configure Autodiscovery (previously known as Service Discovery):
 
    - `SD_BACKEND`: set to `docker` (the only supported backend) to enable Autodiscovery.
-   - `SD_CONFIG_BACKEND`: set to `etcd`, `consul`, or `zookeeper` to use one of these key-value stores as a template source.
+   - `SD_CONFIG_BACKEND`: set to `etcd`, `consul`, or `zk` to use one of these key-value stores as a template source.
    - `SD_BACKEND_HOST` and `SD_BACKEND_PORT`: configure the connection to the key-value template source.
    - `SD_TEMPLATE_DIR`: when using SD_CONFIG_BACKEND, set the path where the check configuration templates are located in the key-value store (default is `datadog/check_configs`)
    - `SD_CONSUL_TOKEN`: when using Consul as a template source and the Consul cluster requires authentication, set a token so the Datadog Agent can connect.

--- a/config_builder.py
+++ b/config_builder.py
@@ -125,10 +125,13 @@ class ConfBuilder(object):
         Used for building datadog.conf
         Sets sd_config_backend and sd_backend_host depending on the environment
         '''
-        _config_backend = getenv('SD_CONFIG_BACKEND', 'sd_config_backend')
+        _config_backend = getenv('SD_CONFIG_BACKEND')
         if _config_backend is not None:
-            _backend_host = getenv('SD_BACKEND_HOST', 'sd_backend_host')
-            if _backend_host is None:
+            self.set_property('sd_config_backend', _config_backend)
+            _backend_host = getenv('SD_BACKEND_HOST')
+            if _backend_host is not None:
+                self.set_property('sd_backend_host', _backend_host)
+            else:
                 _timeout = getdefaulttimeout()
                 try:
                     setdefaulttimeout(1)


### PR DESCRIPTION
### What does this PR do?

Fixes `sd_config_backend` and `sd_backend_host` variables that weren't being written to `datadog.conf`

(fixes regression introduced in #222)

### Testing

Built a custom image with the updated script, seems to fix the issue

### Additional Notes

Also sneaked in a small fix to the README (`sd_backend_host` for Zookeeper needs to be `zk` instead of `zookeeper`)
