### PR TITLE
add DD_DEBUG_MODE envvar and debug_mode.sh script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,8 @@ COPY conf.d/docker_daemon.yaml ${DD_ETC_ROOT}/conf.d/docker_daemon.yaml
 # Add install and config files
 COPY entrypoint.sh /entrypoint.sh
 COPY config_builder.py /config_builder.py
+# Add debug_mode script
+COPY debug_mode.sh /usr/local/bin/debug_mode.sh
 
 # Extra conf.d and checks.d
 VOLUME ["/conf.d", "/checks.d"]

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -36,6 +36,8 @@ COPY conf.d/docker_daemon.yaml "${DD_ETC_ROOT}/conf.d/docker_daemon.yaml"
 # Add install and config files
 COPY entrypoint.sh /entrypoint.sh
 COPY config_builder.py /config_builder.py
+# Add debug_mode script
+COPY debug_mode.sh /usr/local/bin/debug_mode.sh
 
 # Extra conf.d and checks.d
 VOLUME ["/conf.d", "/checks.d"]

--- a/Dockerfile-dogstatsd
+++ b/Dockerfile-dogstatsd
@@ -22,6 +22,8 @@ RUN echo "deb http://apt.datadoghq.com/ stable main" > /etc/apt/sources.list.d/d
 COPY entrypoint-dogstatsd.sh /entrypoint.sh
 COPY dogstatsd/supervisor.conf /etc/dd-agent/supervisor.conf
 COPY config_builder.py /config_builder.py
+# Add debug_mode script
+COPY debug_mode.sh /usr/local/bin/debug_mode.sh
 
 RUN mv /etc/dd-agent/datadog.conf.example /etc/dd-agent/datadog.conf \
  # Set proper permissions to allow running as a non-root user

--- a/Dockerfile-dogstatsd-alpine
+++ b/Dockerfile-dogstatsd-alpine
@@ -30,6 +30,8 @@ RUN apk add -qU --no-cache -t .build-deps curl gcc musl-dev pgcluster-dev linux-
 COPY entrypoint-dogstatsd.sh /entrypoint.sh                   
 COPY dogstatsd/supervisor-alpine.conf $DD_HOME/agent/supervisor.conf
 COPY config_builder.py /config_builder.py 
+# Add debug_mode script
+COPY debug_mode.sh /usr/local/bin/debug_mode.sh
 
 # Set proper permissions to allow running as a non-root user
 RUN  mv $DD_HOME/agent/datadog.conf.example $DD_HOME/agent/datadog.conf \

--- a/Dockerfile-jmx
+++ b/Dockerfile-jmx
@@ -32,6 +32,8 @@ COPY conf.d/docker_daemon.yaml ${DD_ETC_ROOT}/conf.d/docker_daemon.yaml
 # Add install and config files                      
 COPY entrypoint.sh /entrypoint.sh                   
 COPY config_builder.py /config_builder.py
+# Add debug_mode script
+COPY debug_mode.sh /usr/local/bin/debug_mode.sh
 
 # Extra conf.d and checks.d
 VOLUME ["/conf.d", "/checks.d"]

--- a/debug_mode.sh
+++ b/debug_mode.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+#set -e
+
+# Debian images
+if [ -f /etc/debian_version ]
+then
+  apt-get update > /dev/null
+  apt-get install --no-install-recommends -y vim curl less  > /dev/null
+  # Allow to skip -c argument to supervisorctl
+  ln -s /etc/dd-agent/supervisor.conf /etc/supervisord.conf
+
+  echo '#!/bin/sh' > /usr/local/bin/restart-collector
+  echo '/opt/datadog-agent/bin/supervisorctl -c /etc/dd-agent/supervisor.conf restart datadog-agent:collector' >> /usr/local/bin/restart-collector
+  chmod +x /usr/local/bin/restart-collector
+fi
+
+# Alpine images
+if [ -f /etc/alpine-release ]
+then
+  apk update > /dev/null
+  apk add bash curl vim less  > /dev/null
+
+  echo '#!/bin/sh' > /usr/local/bin/restart-collector
+  echo '/opt/datadog-agent/venv/bin/supervisorctl -c /opt/datadog-agent/agent/supervisor.conf restart datadog-agent:collector' >> /usr/local/bin/restart-collector
+  chmod +x /usr/local/bin/restart-collector
+fi

--- a/entrypoint-dogstatsd.sh
+++ b/entrypoint-dogstatsd.sh
@@ -14,6 +14,12 @@ python /config_builder.py
 # ensure that the trace-agent doesn't run unless instructed to
 export DD_APM_ENABLED=${DD_APM_ENABLED:-false}
 
+##### Optionnal debug mode #####
+
+if [ $DD_DEBUG_MODE ]; then
+  sh /usr/local/bin/debug_mode.sh
+fi
+
 ##### Starting up #####
 
 if [ -z $DD_HOSTNAME ] && [ $DD_APM_ENABLED ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -89,6 +89,11 @@ find /conf.d -name '*.yaml' -exec cp --parents {} ${DD_ETC_ROOT} \;
 
 find /checks.d -name '*.py' -exec cp --parents {} ${DD_ETC_ROOT} \;
 
+##### Optionnal debug mode #####
+
+if [ $DD_DEBUG_MODE ]; then
+  sh /usr/local/bin/debug_mode.sh
+fi
 
 ##### Starting up #####
 


### PR DESCRIPTION
### What does this PR do?

Add a `debug_mode.sh` script to be called manually or through the `DD_DEBUG_MODE` envvar binding. It adds:
  - `vim`, `less`, `bash` (on alpine)
  - `restart-collector` helper script to restart collector via `supervisorctl`
  - on debian image, links `supervisor.conf` to its default location to remove the need to give it to `supervisorctl`

Previous refactor already set `$PATH` to sane defaults with all embedded utils (curl, tar, bzip2) and `supervisorctl` reachable.

### Motivation

Easier development and debugging