### PR TITLE
Fix Alpine's LOGS_STDOUT functionality

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,7 +21,10 @@ fi
 
 if [ "$LOGS_STDOUT" = "yes" ]; then
   sed -i -e "/^.*_logfile.*$/d" ${DD_ETC_ROOT}/supervisor.conf
-  sed -i -e "/^.*\[program:.*\].*$/a stdout_logfile=\/dev\/stdout\nstdout_logfile_maxbytes=0\nstderr_logfile=\/dev\/stderr\nstderr_logfile_maxbytes=0" ${DD_ETC_ROOT}/supervisor.conf
+  sed -i -e '/^.*\[program:.*\].*$/a stdout_logfile=\/dev\/stdout\
+stdout_logfile_maxbytes=0\
+stderr_logfile=\/dev\/stderr\
+stderr_logfile_maxbytes=0' ${DD_ETC_ROOT}/supervisor.conf
 fi
 
 ##### Integrations config #####


### PR DESCRIPTION
Currently, if you try and use `DD_LOGS_STDOUT` with the alpine image you get the following error from the entrypoint script:

```
Error: The directory named as part of the path 
/dev/stdoutnstdout_logfile_maxbytes=0nstderr_logfile=/dev/stderrnstderr_logfile_maxbytes=0
does not exist. in section ‘program:forwarder’ (file: ‘agent/supervisor.conf’)
```

This is caused by the newlines not being properly interpreted by busybox's `sed` implementation.
