### PR TITLE
port LOGS_STDOUT to dsd images

### DIFF
--- a/entrypoint-dogstatsd.sh
+++ b/entrypoint-dogstatsd.sh
@@ -11,6 +11,18 @@ fi
 ##### Core config #####
 python /config_builder.py
 
+if [ $DD_LOGS_STDOUT ]; then
+  export LOGS_STDOUT=$DD_LOGS_STDOUT
+fi
+
+if [ "$LOGS_STDOUT" = "yes" ]; then
+  sed -i -e "/^.*_logfile.*$/d" ${DD_ETC_ROOT}/supervisor.conf
+  sed -i -e '/^.*\[program:.*\].*$/a stdout_logfile=\/dev\/stdout\
+stdout_logfile_maxbytes=0\
+stderr_logfile=\/dev\/stderr\
+stderr_logfile_maxbytes=0' ${DD_ETC_ROOT}/supervisor.conf
+fi
+
 # ensure that the trace-agent doesn't run unless instructed to
 export DD_APM_ENABLED=${DD_APM_ENABLED:-false}
 


### PR DESCRIPTION
### What does this PR do?

Ports the support of DD_LOGS_STDOUT envvar for the dsd images. Should address the last inconsistency from https://github.com/DataDog/docker-dd-agent/pull/228

Uses the fixed sed invocation from https://github.com/DataDog/docker-dd-agent/pull/234