### PR TITLE
update config_builder and readme about non-local traffic

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ docker run -d --name dd-agent \
   -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
   -e API_KEY={your_api_key_here} \
   -e SD_BACKEND=docker \
-  datadog/docker-dd-agent
+  -e NON_LOCAL_TRAFFIC=false \
+  datadog/docker-dd-agent:latest
 ```
 
 If you are running on Amazon Linux, use the following instead:
@@ -26,7 +27,8 @@ docker run -d --name dd-agent \
   -v /cgroup/:/host/sys/fs/cgroup:ro \
   -e API_KEY={your_api_key_here} \
   -e SD_BACKEND=docker \
-  datadog/docker-dd-agent
+  -e NON_LOCAL_TRAFFIC=false \
+  datadog/docker-dd-agent:latest
 ```
 
 
@@ -62,8 +64,7 @@ Some configuration parameters can be changed with environment variables:
 * `DD_LOGS_STDOUT`: set it to `yes` to send all logs to stdout and stderr, for them to be processed by Docker.
 * `PROXY_HOST`, `PROXY_PORT`, `PROXY_USER` and `PROXY_PASSWORD` set the proxy configuration.
 * `DD_URL` set the Datadog intake server to send Agent data to (used when [using an agent as a proxy](https://github.com/DataDog/dd-agent/wiki/Proxy-Configuration#using-the-agent-as-a-proxy) )
-* `NON_LOCAL_TRAFFIC` tells the image to set the `non_local_traffic: true` option, which enables statsd reporting from any external ip. You may find this useful to report metrics from your other containers. See [network configuration](https://github.com/DataDog/dd-agent/wiki/Network-Traffic-and-Proxy-Configuration) for more details.
-* ~~`DOGSTATSD_ONLY` tell the image to only start a standalone dogstatsd instance.~~ **[deprecated]: please use [the dogstatsd-only image](#standalone-dogstatsd)**
+* `NON_LOCAL_TRAFFIC` configures the `non_local_traffic` option in the agent which enables or disables statsd reporting from **any** external ip. You may find this useful to report metrics from your other containers. See [network configuration](https://github.com/DataDog/dd-agent/wiki/Network-Traffic-and-Proxy-Configuration) for more details. This option is set to true by default in the image, and the `docker run` command we provide in the example above disables it. Remove the `-e NON_LOCAL_TRAFFIC=false` part to enable it back. **WARNING** if you allow non-local traffic, make sure your agent container is not accessible from the Internet or other untrusted networks as it would allow anyone to submit metrics to it.
 * `SD_BACKEND`, `SD_CONFIG_BACKEND`, `SD_BACKEND_HOST`, `SD_BACKEND_PORT`, `SD_TEMPLATE_DIR`, `SD_CONSUL_TOKEN`, `SD_BACKEND_USER` and `SD_BACKEND_PASSWORD` configure Autodiscovery (previously known as Service Discovery):
 
    - `SD_BACKEND`: set to `docker` (the only supported backend) to enable Autodiscovery.

--- a/config_builder.py
+++ b/config_builder.py
@@ -9,6 +9,7 @@ from urllib2 import urlopen, URLError, HTTPError
 from socket import getdefaulttimeout, setdefaulttimeout
 from ConfigParser import ConfigParser
 
+
 class ConfBuilder(object):
     '''
     This class manages the configuration files
@@ -27,7 +28,6 @@ class ConfBuilder(object):
         self.datadog_conf_file = '{}/datadog.conf'.format(dd_agent_root)
         # This will store the config parser object that is used in the different functions
         self.config = None
-
 
     def load_config(self, config_file):
         '''
@@ -64,7 +64,7 @@ class ConfBuilder(object):
         # The LOG_LEVEL env variable superseeds DD_LOG_LEVEL
         self.set_from_env_mapping('DD_LOG_LEVEL', 'log_level')
         self.set_from_env_mapping('LOG_LEVEL', 'log_level')
-        self.set_from_env_mapping('NON_LOCAL_TRAFFIC', 'non_local_traffic', action='store_true')
+        self.set_from_env_mapping('NON_LOCAL_TRAFFIC', 'non_local_traffic')
         self.set_from_env_mapping('DD_URL', 'dd_url')
         self.set_from_env_mapping('STATSD_METRIC_NAMESPACE', 'statsd_metric_namespace')
         self.set_from_env_mapping('USE_DOGSTATSD', 'use_dogstatsd')
@@ -138,7 +138,7 @@ class ConfBuilder(object):
                     _ec2_ip = urlopen('http://169.254.169.254/latest/meta-data/local-ipv4')
                     self.set_property('sd_backend_host', _ec2_ip.read())
                 except (URLError, HTTPError):
-                    pass # silent fail on purpose
+                    pass  # silent fail on purpose
                 setdefaulttimeout(_timeout)
 
     def set_generics(self, prefix='DD_CONF_'):


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*


### What does this PR do?

- update config_builder.py to allow disabling non-local traffic
- update readme with updated docker run example that disables non-local traffic and explain the consequences of enabling it

### Motivation

security!

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
