### PR TITLE
Enable to set Trace Environment via env-var

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,6 +27,12 @@ stderr_logfile=\/dev\/stderr\
 stderr_logfile_maxbytes=0' ${DD_ETC_ROOT}/supervisor.conf
 fi
 
+##### Trace Agent config #####
+if [ ! "${DD_TRACE_CONF_ENV}" = "" ]; then
+  sed -i -e '$ a [trace.config]' ${DD_ETC_ROOT}/datadog.conf
+  sed -i -e "$ a env = ${DD_TRACE_CONF_ENV}" ${DD_ETC_ROOT}/datadog.conf
+fi
+
 ##### Integrations config #####
 
 if [ $KUBERNETES ]; then


### PR DESCRIPTION
### What does this PR do?
Enable to set Trace Environment.

For example, when you add `DD_TRACE_CONF_ENV=staging` to docker-dd-agent container, new lines will be added in `datadog.conf` like this:

```
[trace.config]
env = staging
```

#### About implementation
I understand you manage configurations in `datadog.conf` by `config_builder.py`. At first I tried to modify the file. But it looks `config_builder.py` doesn't support trace conf currently. Then I modified `entrypoint.sh` instead of `config_builder.py` .   I don't know this is right way. So I'd like to hear maintainers feedback. 

### Motivation
To allow docker-dd-agent users to set [Trace Environment](https://docs.datadoghq.com/tracing/environments/) via environment variable. 

I have multiple Kubernetes clusters such as "production", "staging". I run docker-dd-agent as daemonSets in each cluster. I have started to use Datadog APM on those cluster. To avoid to force each tracer to set "env" (because our development team is planning to deploy tons of services), I'd like to set it via trace agent. But currently it looks docker-dd-agent doesn't allow to set it via environment variable.
