### PR TITLE
add HISTOGRAM_PERCENTILES and SD_JMX_ENABLE to config_builder.py

### DIFF
--- a/config_builder.py
+++ b/config_builder.py
@@ -68,6 +68,7 @@ class ConfBuilder(object):
         self.set_from_env_mapping('DD_URL', 'dd_url')
         self.set_from_env_mapping('STATSD_METRIC_NAMESPACE', 'statsd_metric_namespace')
         self.set_from_env_mapping('USE_DOGSTATSD', 'use_dogstatsd')
+        self.set_from_env_mapping('DD_HISTOGRAM_PERCENTILES', 'histogram_percentiles')
         ##### Proxy config #####
         self.set_from_env_mapping('PROXY_HOST', 'proxy_host')
         self.set_from_env_mapping('PROXY_PORT', 'proxy_port')


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*


### What does this PR do?

adds histogram_percentile and sd_jmx_enable settings via ENV Var to config_builder.py

### Motivation

These settings are not easily configurable in the image currently.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
