### PR TITLE
DD_COLLECT_LABELS_AS_TAGS as an environment variable 

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Some configuration parameters can be changed with environment variables:
    - `SD_BACKEND_USER` and `SD_BACKEND_PASSWORD`: when using etcd as a template source and it requires authentication, set a user and password so the Datadog Agent can connect.
 
 * `DD_APM_ENABLED` run the trace-agent along with the infrastructure agent, allowing the container to accept traces on 8126/tcp (**This option is NOT available on Alpine Images**)
+* `COLLECT_LABELS_AS_TAGS` Enables the collection of the listed labels as tags. Comma separated string, without spaces unless in quotes. Exemple: `-e COLLECT_LABELS_AS_TAGS='com.docker.label.foo, com.docker.label.bar'` or `-e COLLECT_LABELS_AS_TAGS=com.docker.label.foo,com.docker.label.bar`.
 
 **Note:** it is possible to use `DD_TAGS` instead of `TAGS`, `DD_LOG_LEVEL` instead of `LOG_LEVEL` and `DD_API_KEY` instead of `API_KEY`, these variables have the same impact.
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Some configuration parameters can be changed with environment variables:
    - `SD_BACKEND_USER` and `SD_BACKEND_PASSWORD`: when using etcd as a template source and it requires authentication, set a user and password so the Datadog Agent can connect.
 
 * `DD_APM_ENABLED` run the trace-agent along with the infrastructure agent, allowing the container to accept traces on 8126/tcp (**This option is NOT available on Alpine Images**)
-* `COLLECT_LABELS_AS_TAGS` Enables the collection of the listed labels as tags. Comma separated string, without spaces unless in quotes. Exemple: `-e COLLECT_LABELS_AS_TAGS='com.docker.label.foo, com.docker.label.bar'` or `-e COLLECT_LABELS_AS_TAGS=com.docker.label.foo,com.docker.label.bar`.
+* `DD_COLLECT_LABELS_AS_TAGS` Enables the collection of the listed labels as tags. Comma separated string, without spaces unless in quotes. Exemple: `-e DD_COLLECT_LABELS_AS_TAGS='com.docker.label.foo, com.docker.label.bar'` or `-e DD_COLLECT_LABELS_AS_TAGS=com.docker.label.foo,com.docker.label.bar`.
 
 **Note:** it is possible to use `DD_TAGS` instead of `TAGS`, `DD_LOG_LEVEL` instead of `LOG_LEVEL` and `DD_API_KEY` instead of `API_KEY`, these variables have the same impact.
 

--- a/config_builder.py
+++ b/config_builder.py
@@ -61,7 +61,7 @@ class ConfBuilder(object):
         # The TAGS env variable superseeds DD_TAGS
         self.set_from_env_mapping('DD_TAGS', 'tags')
         self.set_from_env_mapping('TAGS', 'tags')
-        self.set_from_env_mapping('COLLECT_LABELS_AS_TAGS', 'docker_labels_as_tags')
+        self.set_from_env_mapping('DD_COLLECT_LABELS_AS_TAGS', 'docker_labels_as_tags')
         # The LOG_LEVEL env variable superseeds DD_LOG_LEVEL
         self.set_from_env_mapping('DD_LOG_LEVEL', 'log_level')
         self.set_from_env_mapping('LOG_LEVEL', 'log_level')

--- a/config_builder.py
+++ b/config_builder.py
@@ -61,6 +61,7 @@ class ConfBuilder(object):
         # The TAGS env variable superseeds DD_TAGS
         self.set_from_env_mapping('DD_TAGS', 'tags')
         self.set_from_env_mapping('TAGS', 'tags')
+        self.set_from_env_mapping('COLLECT_LABELS_AS_TAGS', 'docker_labels_as_tags')
         # The LOG_LEVEL env variable superseeds DD_LOG_LEVEL
         self.set_from_env_mapping('DD_LOG_LEVEL', 'log_level')
         self.set_from_env_mapping('LOG_LEVEL', 'log_level')

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -61,10 +61,6 @@ if [ $KUBERNETES ]; then
 
 fi
 
-if [ $COLLECT_LABELS_AS_TAGS ]; then
-  sed -i -e "s@# collect_labels_as_tags: com.docker.compose.service, com.docker.compose.project@collect_labels_as_tags: $COLLECT_LABELS_AS_TAGS@" ${DD_ETC_ROOT}/conf.d/docker_daemon.yaml
-fi
-
 if [ $MESOS_MASTER ]; then
   cp ${DD_ETC_ROOT}/conf.d/mesos_master.yaml.example ${DD_ETC_ROOT}/conf.d/mesos_master.yaml
   cp ${DD_ETC_ROOT}/conf.d/zk.yaml.example ${DD_ETC_ROOT}/conf.d/zk.yaml

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -61,6 +61,10 @@ if [ $KUBERNETES ]; then
 
 fi
 
+if [ $COLLECT_LABELS_AS_TAGS ]; then
+  sed -i -e "s@# collect_labels_as_tags: com.docker.compose.service, com.docker.compose.project@collect_labels_as_tags: $COLLECT_LABELS_AS_TAGS@" ${DD_ETC_ROOT}/conf.d/docker_daemon.yaml
+fi
+
 if [ $MESOS_MASTER ]; then
   cp ${DD_ETC_ROOT}/conf.d/mesos_master.yaml.example ${DD_ETC_ROOT}/conf.d/mesos_master.yaml
   cp ${DD_ETC_ROOT}/conf.d/zk.yaml.example ${DD_ETC_ROOT}/conf.d/zk.yaml


### PR DESCRIPTION
### What does this PR do?

Adds the collect_labels_as_tags as an Environment variable:
see https://github.com/DataDog/integrations-core/pull/881

### Motivation

Requested by the community.

### Testing Guidelines

Successfully tested locally.

- [ ] Create a Backported image