### PR TITLE
move the supervisord socket to /dev/shm

### DIFF
--- a/entrypoint-dogstatsd.sh
+++ b/entrypoint-dogstatsd.sh
@@ -23,6 +23,10 @@ stderr_logfile=\/dev\/stderr\
 stderr_logfile_maxbytes=0' ${DD_ETC_ROOT}/supervisor.conf
 fi
 
+# Move the supervisord socket to /dev/shm to circumvent
+# https://github.com/Supervisor/supervisor/issues/654
+sed -i "s@/opt/datadog-agent/run/datadog-supervisor.sock@/dev/shm/datadog-supervisor.sock@" ${DD_ETC_ROOT}/supervisor.conf
+
 # ensure that the trace-agent doesn't run unless instructed to
 export DD_APM_ENABLED=${DD_APM_ENABLED:-false}
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,6 +27,10 @@ stderr_logfile=\/dev\/stderr\
 stderr_logfile_maxbytes=0' ${DD_ETC_ROOT}/supervisor.conf
 fi
 
+# Move the supervisord socket to /dev/shm to circumvent
+# https://github.com/Supervisor/supervisor/issues/654
+sed -i "s@/opt/datadog-agent/run/datadog-supervisor.sock@/dev/shm/datadog-supervisor.sock@" ${DD_ETC_ROOT}/supervisor.conf
+
 ##### Integrations config #####
 
 if [ $KUBERNETES ]; then


### PR DESCRIPTION
Some linux versions have issues with storing unix sockets in `overlay` volumes, making the healthcheck fail:

- https://github.com/Supervisor/supervisor/issues/654
- https://github.com/moby/moby/issues/12080

This PR moves the sock to `/dev/shm` that is a `tmpfs` as a workaround for these hosts with an affected kernel.

Image `datadog/dev-dd-agent:xvello_sock_in_shm` tested and confirmed by affected user.