### PR TITLE
set the supervisor_socket option to fix jmxfetch AD

### DIFF
--- a/entrypoint-dogstatsd.sh
+++ b/entrypoint-dogstatsd.sh
@@ -8,6 +8,11 @@ if [ -n $DD_HOME ]; then
   fi
 fi
 
+# Move the supervisord socket to /dev/shm to circumvent
+# https://github.com/Supervisor/supervisor/issues/654
+sed -i "s@/opt/datadog-agent/run/datadog-supervisor.sock@/dev/shm/datadog-supervisor.sock@" ${DD_ETC_ROOT}/supervisor.conf
+export DD_CONF_SUPERVISOR_SOCKET="/dev/shm/datadog-supervisor.sock"
+
 ##### Core config #####
 python /config_builder.py
 
@@ -22,10 +27,6 @@ stdout_logfile_maxbytes=0\
 stderr_logfile=\/dev\/stderr\
 stderr_logfile_maxbytes=0' ${DD_ETC_ROOT}/supervisor.conf
 fi
-
-# Move the supervisord socket to /dev/shm to circumvent
-# https://github.com/Supervisor/supervisor/issues/654
-sed -i "s@/opt/datadog-agent/run/datadog-supervisor.sock@/dev/shm/datadog-supervisor.sock@" ${DD_ETC_ROOT}/supervisor.conf
 
 # ensure that the trace-agent doesn't run unless instructed to
 export DD_APM_ENABLED=${DD_APM_ENABLED:-false}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,6 +8,12 @@ if [ -n $DD_HOME ]; then
   fi
 fi
 
+# Move the supervisord socket to /dev/shm to circumvent
+# https://github.com/Supervisor/supervisor/issues/654
+sed -i "s@/opt/datadog-agent/run/datadog-supervisor.sock@/dev/shm/datadog-supervisor.sock@" ${DD_ETC_ROOT}/supervisor.conf
+export DD_CONF_SUPERVISOR_SOCKET="/dev/shm/datadog-supervisor.sock"
+
+
 ##### Core config #####
 python /config_builder.py
 
@@ -26,10 +32,6 @@ stdout_logfile_maxbytes=0\
 stderr_logfile=\/dev\/stderr\
 stderr_logfile_maxbytes=0' ${DD_ETC_ROOT}/supervisor.conf
 fi
-
-# Move the supervisord socket to /dev/shm to circumvent
-# https://github.com/Supervisor/supervisor/issues/654
-sed -i "s@/opt/datadog-agent/run/datadog-supervisor.sock@/dev/shm/datadog-supervisor.sock@" ${DD_ETC_ROOT}/supervisor.conf
 
 ##### Integrations config #####
 


### PR DESCRIPTION
### What does this PR do?

https://github.com/DataDog/docker-dd-agent/pull/269 moved the supervisord unix socket to `/dev/shm/` instead of the default `/opt/datadog-agent/run/`.

This breaks the [link between the collector and supervisord](https://github.com/DataDog/dd-agent/blob/a8d6a47cf001f9fc7c336c822718fea1e5bf890b/agent.py#L429) for jmxfetch management. This PR fixes it by setting the `supervisor_socket` option in `datadog.conf` so that the collector can communicate with supervisord.

### Motivation

Bug report