### PR TITLE
Configuration: configure the network check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ ENV DOCKER_DD_AGENT=yes \
     PYTHONPATH=/opt/datadog-agent/agent \
     DD_CONF_LOG_TO_SYSLOG=no \
     NON_LOCAL_TRAFFIC=yes \
-    DD_SUPERVISOR_DELETE_USER=yes
+    DD_SUPERVISOR_DELETE_USER=yes \
+    DD_CONF_PROCFS_PATH="/host/proc"
 
 # Install the Agent
 RUN echo "deb http://apt.datadoghq.com/ stable main" > /etc/apt/sources.list.d/datadog.list \
@@ -29,7 +30,6 @@ COPY probe.sh /probe.sh
 # 3. Make healthcheck script executable
 RUN mv ${DD_ETC_ROOT}/datadog.conf.example ${DD_ETC_ROOT}/datadog.conf \
  && sed -i 's/AGENTUSER="dd-agent"/AGENTUSER="root"/g' /etc/init.d/datadog-agent \
- && rm -f ${DD_ETC_ROOT}/conf.d/network.yaml.default \
  && chmod +x /etc/init.d/datadog-agent \
  && chmod +x /probe.sh
 

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -13,7 +13,8 @@ ENV DD_HOME=/opt/datadog-agent \
     PYTHONPATH="/opt/datadog-agent/agent" \
     DD_CONF_LOG_TO_SYSLOG=no \
     NON_LOCAL_TRAFFIC=yes \
-    DD_SUPERVISOR_DELETE_USER=yes
+    DD_SUPERVISOR_DELETE_USER=yes \
+    DD_CONF_PROCFS_PATH="/host/proc"
 
 # Install minimal dependencies
 RUN apk add -qU --no-cache coreutils curl curl-dev python-dev tar sysstat tini
@@ -34,7 +35,6 @@ COPY probe-alpine.sh $DD_HOME/probe.sh
 # Configure the Agent
 # and make healthcheck script executable
 RUN cp ${DD_ETC_ROOT}/datadog.conf.example ${DD_ETC_ROOT}/datadog.conf \
-  && rm -f ${DD_ETC_ROOT}/conf.d/network.yaml.default \
   && chmod +x $DD_HOME/probe.sh
 
 # Add Docker check

--- a/Dockerfile-jmx
+++ b/Dockerfile-jmx
@@ -10,7 +10,8 @@ ENV DOCKER_DD_AGENT=yes \
     DD_CONF_SD_JMX_ENABLE=yes \
     DD_CONF_LOG_TO_SYSLOG=no \
     NON_LOCAL_TRAFFIC=yes \
-    DD_SUPERVISOR_DELETE_USER=yes
+    DD_SUPERVISOR_DELETE_USER=yes \
+    DD_CONF_PROCFS_PATH="/host/proc"
 
 # Install the Agent
 RUN echo "deb http://apt.datadoghq.com/ stable main" > /etc/apt/sources.list.d/datadog.list \
@@ -27,7 +28,6 @@ COPY probe.sh /probe.sh
 # Configure the Agent
 RUN mv ${DD_ETC_ROOT}/datadog.conf.example ${DD_ETC_ROOT}/datadog.conf \
  && sed -i 's/AGENTUSER="dd-agent"/AGENTUSER="root"/g' /etc/init.d/datadog-agent \
- && rm -f ${DD_ETC_ROOT}/conf.d/network.yaml.default \
  && chmod +x /etc/init.d/datadog-agent \
  && chmod +x /probe.sh
 

--- a/Dockerfile-rhel
+++ b/Dockerfile-rhel
@@ -9,7 +9,8 @@ ENV DOCKER_DD_AGENT=yes \
     PYTHONPATH=/opt/datadog-agent/agent \
     DD_CONF_LOG_TO_SYSLOG=no \
     NON_LOCAL_TRAFFIC=yes \
-    DD_SUPERVISOR_DELETE_USER=yes
+    DD_SUPERVISOR_DELETE_USER=yes \
+    DD_CONF_PROCFS_PATH="/host/proc"
 
 LABEL name="datadog/docker-dd-agent:latest-rhel" \
       vendor="Datadog" \
@@ -48,7 +49,6 @@ RUN yum -y install datadog-agent-${AGENT_VERSION} \
  && sed -i -e"s/^.*log_to_syslog:.*$/log_to_syslog: no/" /etc/dd-agent/datadog.conf \
  && sed -i "/user=dd-agent/d" /etc/dd-agent/supervisor.conf \
  && sed -i 's/AGENTUSER="dd-agent"/AGENTUSER="root"/g' /etc/init.d/datadog-agent \
- && rm /etc/dd-agent/conf.d/network.yaml.default \
  && chmod +x /probe.sh
 
 # Add Docker check


### PR DESCRIPTION
### What does this PR do?

The PR [integration-cores #994](https://github.com/DataDog/integrations-core/pull/994) allows to collect some network metrics inside a container.

This PR set the associated configuration to use this new feature.

### Testing Guidelines

**Dockerfile:**

```bash
docker run --rm -it -e DD_API_KEY=1234er local /bin/sh -c 'cat /etc/os-release ; cat /etc/dd-agent/datadog.conf ; ls -l /etc/dd-agent/conf.d/network.yaml.default'
PRETTY_NAME="Debian GNU/Linux 8 (jessie)"
NAME="Debian GNU/Linux"
VERSION_ID="8"
VERSION="8 (jessie)"
ID=debian
HOME_URL="http://www.debian.org/"
SUPPORT_URL="http://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"
[Main]
dd_url = https://app.datadoghq.com
api_key = 1234er
gce_updated_hostname = yes
non_local_traffic = yes
supervisor_socket = /dev/shm/datadog-supervisor.sock
log_to_syslog = no
procfs_path = /host/proc

-rw-r--r-- 1 root root 790 Dec  6 19:47 /etc/dd-agent/conf.d/network.yaml.default
```

**Dockerfile-alpine:**
```bash
docker run --rm -it -e DD_API_KEY=1234er local /bin/sh -c 'cat /etc/os-release ; cat /opt/datadog-dog-agent/agent/conf.d/network.yaml.default'
NAME="Alpine Linux"
ID=alpine
VERSION_ID=3.6.2
PRETTY_NAME="Alpine Linux v3.6"
HOME_URL="http://alpinelinux.org"
BUG_REPORT_URL="http://bugs.alpinelinux.org"
[Main]
dd_url = https://app.datadoghq.com
api_key = 1234er
jmxfetch_log_file = /opt/datadog-agent/logs/jmxfetch.log
dogstatsd_log_file = /opt/datadog-agent/logs/dogstatsd.log
forwarder_log_file = /opt/datadog-agent/logs/forwarder.log
collector_log_file = /opt/datadog-agent/logs/collector.log
gce_updated_hostname = yes
non_local_traffic = yes
supervisor_socket = /dev/shm/datadog-supervisor.sock
procfs_path = /host/proc
log_to_syslog = no

-rw-r--r-- 1 root root 790 Jan  9 09:46 /opt/datadog-agent/agent/conf.d/network.yaml.default
```

**Dockerfile-jmx:**
```bash
docker run --rm -it -e DD_API_KEY=1234er local /bin/sh -c 'cat /etc/os-release ; cat /etc/dd-agent/datadog.conf ; ls -l /etc/dd-agent/conf.d/network.yaml.default ; echo ${DD_CONF_SD_JMX_ENABLE}'
PRETTY_NAME="Debian GNU/Linux 8 (jessie)"
NAME="Debian GNU/Linux"
VERSION_ID="8"
VERSION="8 (jessie)"
ID=debian
HOME_URL="http://www.debian.org/"
SUPPORT_URL="http://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"
[Main]
dd_url = https://app.datadoghq.com
api_key = 1234er
gce_updated_hostname = yes
non_local_traffic = yes
supervisor_socket = /dev/shm/datadog-supervisor.sock
sd_jmx_enable = yes
log_to_syslog = no
procfs_path = /host/proc

-rw-r--r-- 1 root root 790 Dec  6 19:47 /etc/dd-agent/conf.d/network.yaml.default
yes
```

**Dockerfile-rhel**:
```sudo docker run --rm -it -e DD_API_KEY=1234er local /bin/sh -c 'cat /etc/os-release ; cat /etc/dd-agent/datadog.conf ; ls -l /etc/dd-agent/conf.d/network.yaml.default'
NAME="Red Hat Enterprise Linux Server"
VERSION="7.4 (Maipo)"
ID="rhel"
ID_LIKE="fedora"
VARIANT="Server"
VARIANT_ID="server"
VERSION_ID="7.4"
PRETTY_NAME="Red Hat Enterprise Linux Server 7.4 (Maipo)"
ANSI_COLOR="0;31"
CPE_NAME="cpe:/o:redhat:enterprise_linux:7.4:GA:server"
HOME_URL="https://www.redhat.com/"
BUG_REPORT_URL="https://bugzilla.redhat.com/"

REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 7"
REDHAT_BUGZILLA_PRODUCT_VERSION=7.4
REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"
REDHAT_SUPPORT_PRODUCT_VERSION="7.4"
[Main]
dd_url = https://app.datadoghq.com
api_key = 1234er
gce_updated_hostname = yes
non_local_traffic = yes
log_to_syslog = no
supervisor_socket = /dev/shm/datadog-supervisor.sock
procfs_path = /host/proc

[trace.sampler]
extra_sample_rate = 1
max_traces_per_second = 10

[trace.receiver]
receiver_port = 8126
connection_limit = 2000

[trace.ignore]
resource = "GET|POST /healthcheck","GET /V1"

-rw-r--r--. 4 root root 790 Nov  7 16:28 /etc/dd-agent/conf.d/network.yaml.default```
