### PR TITLE
Adding libffi-dev to alpine images

### DIFF
--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -21,7 +21,7 @@ RUN apk add -qU --no-cache coreutils curl curl-dev python-dev tar sysstat tini
 
 # Install build dependencies
 ADD https://raw.githubusercontent.com/DataDog/dd-agent/master/packaging/datadog-agent/source/setup_agent.sh /tmp/setup_agent.sh
-RUN apk add -qU --no-cache -t .build-deps gcc musl-dev postgresql-dev linux-headers \
+RUN apk add -qU --no-cache -t .build-deps gcc musl-dev postgresql-dev linux-headers libffi-dev \
     # Install the agent
     && sh /tmp/setup_agent.sh \
     # Clean build dependencies

--- a/Dockerfile-dogstatsd-alpine
+++ b/Dockerfile-dogstatsd-alpine
@@ -18,7 +18,7 @@ RUN apk add -qU --no-cache curl-dev python-dev tar sysstat ca-certificates
 
 # Install build dependencies
 ADD https://raw.githubusercontent.com/DataDog/dd-agent/master/packaging/datadog-agent/source/setup_agent.sh /tmp/setup_agent.sh
-RUN apk add -qU --no-cache -t .build-deps curl gcc musl-dev linux-headers \
+RUN apk add -qU --no-cache -t .build-deps curl gcc musl-dev linux-headers libffi-dev \
     # Install the agent
     && sh /tmp/setup_agent.sh \
     # Clean build dependencies


### PR DESCRIPTION
We need `libffi-dev` to `pip install cffi` which is a dependency of our `ssh_check`.