### PR TITLE
Move docker links to legacy in dogstatsd section

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,11 @@ DogStatsd can be disabled by setting `USE_DOGSTATSD` to `no`
 
 ### DogStatsD from other containers
 
-#### Using Docker links
+#### Using Docker host IP
+
+Since the Agent container port 8125 should be linked to the host directly, you can connect to DogStatsD through the host. Usually the IP address of the host in a Docker container can be determined by looking at the address of the default route of this container with `ip route` for example. You can then configure your DogStatsD client to connect to `172.17.42.1:8125` for example.
+
+#### Using Docker links (Legacy)
 
 To send data to DogStatsD from other containers, add a `--link dogstatsd:dogstatsd` option to your run command.
 
@@ -169,9 +173,6 @@ docker run  --name my_container           \
 
 DogStatsD address and port will be available in `my_container`'s environment variables `DOGSTATSD_PORT_8125_UDP_ADDR` and `DOGSTATSD_PORT_8125_UDP_PORT`.
 
-#### Using Docker host IP
-
-Since the Agent container port 8125 should be linked to the host directly, you can connect to DogStatsD through the host. Usually the IP address of the host in a Docker container can be determined by looking at the address of the default route of this container with `ip route` for example. You can then configure your DogStatsD client to connect to `172.17.42.1:8125` for example.
 
 ## Tracing + APM
 


### PR DESCRIPTION
Documentation update, for review

Motivation:
Docker links are legacy: https://docs.docker.com/network/links/
