### PR TITLE
add support for max_traces_per_second option to datadog.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ Some configuration parameters can be changed with environment variables:
 
 * `DD_COLLECT_LABELS_AS_TAGS` Enables the collection of the listed labels as tags. Comma separated string, without spaces unless in quotes. Exemple: `-e DD_COLLECT_LABELS_AS_TAGS='com.docker.label.foo, com.docker.label.bar'` or `-e DD_COLLECT_LABELS_AS_TAGS=com.docker.label.foo,com.docker.label.bar`.
 
+* `MAX_TRACES_PER_SECOND`: Specifies the maximum number of traces per second to sample for APM.  Set to `0` to disable this limit.
+
 **Note:** Some of those have alternative names, but with the same impact: it is possible to use `DD_TAGS` instead of `TAGS`, `DD_LOG_LEVEL` instead of `LOG_LEVEL` and `DD_API_KEY` instead of `API_KEY`.
 
 

--- a/config_builder.py
+++ b/config_builder.py
@@ -85,6 +85,8 @@ class ConfBuilder(object):
         self.set_from_env_mapping('SD_BACKEND_PASSWORD', 'sd_backend_password')
         # Magic trick to automatically add properties not yet define in the doc
         self.set_generics('DD_CONF_')
+        ##### Trace Config #####
+        self.set_from_env_mapping('MAX_TRACES_PER_SECOND', 'max_traces_per_second', 'trace.sampler')
 
         self.save_config(self.datadog_conf_file)
 

--- a/config_builder.py
+++ b/config_builder.py
@@ -159,6 +159,8 @@ class ConfBuilder(object):
         '''
         Sets the given property to the given value in the configuration
         '''
+        if not self.config.has_selection(section):
+            self.config.add_section(section)
         if self.config is None:
             logging.error('config object needs to be created before setting properties')
             exit(1)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,7 +15,6 @@ export DD_CONF_SUPERVISOR_SOCKET="/dev/shm/datadog-supervisor.sock"
 
 
 ##### Core config #####
-sed -i '/^#.* \[trace.sampler\]/s/^# //' ${DD_ETC_ROOT}/datadog.conf
 python /config_builder.py
 
 if [ "${DD_SUPERVISOR_DELETE_USER}" = "yes" ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,6 +15,7 @@ export DD_CONF_SUPERVISOR_SOCKET="/dev/shm/datadog-supervisor.sock"
 
 
 ##### Core config #####
+sed -i '/^#.* \[trace.sampler\]/s/^# //' ${DD_ETC_ROOT}/datadog.conf
 python /config_builder.py
 
 if [ "${DD_SUPERVISOR_DELETE_USER}" = "yes" ]; then


### PR DESCRIPTION
### What does this PR do?
This PR does two things:

* Uncomments the `[trace.sampler]` section in the stock `datadog.conf`
* Adds the `max_traces_per_second` configuration option to `datadog.conf`

This allows a user to configure this value by setting the `MAX_TRACES_PER_SECOND` environment variable.

### Motivation
We are heavy users of APM.  We require a higher `max_traces_per_second` than what the default provides (10).  

### What inspired you to submit this pull request?
The inability to configure `max_traces_per_second` via an environment variable.