### PR TITLE
Update the debian Dockerfile with the new GPG signing key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 12.6.5221 / unreleased
+
+###
+
+- [DEBIAN] use the new GPG signing key for the apt.datadoghq.com repository
+
 ## 12.5.5202 / 2018-01-04
 
 ###

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ENV DOCKER_DD_AGENT=yes \
 
 # Install the Agent
 RUN echo "deb http://apt.datadoghq.com/ stable main" > /etc/apt/sources.list.d/datadog.list \
- && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C7A7DA52 \
+ && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A2923DFF56EDA6E76E55E492D3A80E30382E94DE \
  && apt-get update \
  && apt-get install --no-install-recommends -y datadog-agent="${AGENT_VERSION}" \
  && apt-get install --no-install-recommends -y ca-certificates \

--- a/Dockerfile-dogstatsd
+++ b/Dockerfile-dogstatsd
@@ -12,7 +12,7 @@ ENV DOCKER_DD_AGENT=yes \
 
 # Install the Agent
 RUN echo "deb http://apt.datadoghq.com/ stable main" > /etc/apt/sources.list.d/datadog.list \
- && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C7A7DA52 \
+ && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A2923DFF56EDA6E76E55E492D3A80E30382E94DE \
  && apt-get update \
  && apt-get install --no-install-recommends -y datadog-agent="${AGENT_VERSION}" ca-certificates \
  && apt-get clean \

--- a/Dockerfile-jmx
+++ b/Dockerfile-jmx
@@ -15,7 +15,7 @@ ENV DOCKER_DD_AGENT=yes \
 
 # Install the Agent
 RUN echo "deb http://apt.datadoghq.com/ stable main" > /etc/apt/sources.list.d/datadog.list \
- && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C7A7DA52 \
+ && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A2923DFF56EDA6E76E55E492D3A80E30382E94DE \
  && apt-get update \
  && apt-get install --no-install-recommends -y openjdk-7-jre-headless \
  && apt-get install --no-install-recommends -y datadog-agent="${AGENT_VERSION}" \


### PR DESCRIPTION
### What does this PR do?

The GPG key we use to sign the APT repository has been rotated due to expiration. Update the dockerfiles to trust the new key.
