### PR TITLE
update to stretch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## 12.6.5223 / unreleased
 
-###
-
 - [DEBIAN] use the new GPG signing key for the apt.datadoghq.com repository
 - [DEBIAN] fix the status command
 - [ALL IMAGES] add support for max_traces_per_second option to datadog.conf [#291](https://github.com/DataDog/docker-dd-agent/pull/291)
+- [DEBIAN] update the Debian base image to stretch
+- [JMX] ship openjdk 8u151
 
 ## 12.5.5202 / 2018-01-04
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM debian:stretch
 
 MAINTAINER Datadog <package@datadoghq.com>
 
@@ -13,7 +13,9 @@ ENV DOCKER_DD_AGENT=yes \
     DD_CONF_PROCFS_PATH="/host/proc"
 
 # Install the Agent
-RUN echo "deb http://apt.datadoghq.com/ stable main" > /etc/apt/sources.list.d/datadog.list \
+RUN apt-get update \
+ && apt-get install --no-install-recommends -y gnupg dirmngr \
+ && echo "deb http://apt.datadoghq.com/ stable main" > /etc/apt/sources.list.d/datadog.list \
  && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A2923DFF56EDA6E76E55E492D3A80E30382E94DE \
  && apt-get update \
  && apt-get install --no-install-recommends -y datadog-agent="${AGENT_VERSION}" \

--- a/Dockerfile-dogstatsd
+++ b/Dockerfile-dogstatsd
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM debian:stretch
 
 MAINTAINER Datadog <package@datadoghq.com>
 
@@ -11,10 +11,13 @@ ENV DOCKER_DD_AGENT=yes \
     NON_LOCAL_TRAFFIC=yes
 
 # Install the Agent
-RUN echo "deb http://apt.datadoghq.com/ stable main" > /etc/apt/sources.list.d/datadog.list \
+RUN apt-get update \
+ && apt-get install --no-install-recommends -y gnupg dirmngr \
+ && echo "deb http://apt.datadoghq.com/ stable main" > /etc/apt/sources.list.d/datadog.list \
  && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A2923DFF56EDA6E76E55E492D3A80E30382E94DE \
  && apt-get update \
- && apt-get install --no-install-recommends -y datadog-agent="${AGENT_VERSION}" ca-certificates \
+ && apt-get install --no-install-recommends -y datadog-agent="${AGENT_VERSION}" \
+ && apt-get install --no-install-recommends -y ca-certificates \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
  && sed -i "s@/opt/datadog-agent/run/datadog-supervisor.sock@/dev/shm/datadog-supervisor.sock@" /etc/init.d/datadog-agent

--- a/Dockerfile-jmx
+++ b/Dockerfile-jmx
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM debian:stretch
 
 MAINTAINER Datadog <package@datadoghq.com>
 
@@ -14,11 +14,14 @@ ENV DOCKER_DD_AGENT=yes \
     DD_CONF_PROCFS_PATH="/host/proc"
 
 # Install the Agent
-RUN echo "deb http://apt.datadoghq.com/ stable main" > /etc/apt/sources.list.d/datadog.list \
+RUN apt-get update \
+ && apt-get install --no-install-recommends -y gnupg dirmngr \
+ && echo "deb http://apt.datadoghq.com/ stable main" > /etc/apt/sources.list.d/datadog.list \
  && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A2923DFF56EDA6E76E55E492D3A80E30382E94DE \
  && apt-get update \
- && apt-get install --no-install-recommends -y openjdk-7-jre-headless \
  && apt-get install --no-install-recommends -y datadog-agent="${AGENT_VERSION}" \
+&& apt-get install --no-install-recommends -y openjdk-8-jre-headless \
+ && apt-get install --no-install-recommends -y ca-certificates \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
### What does this PR do?

Update the base image for Debian images to stretch, to bring in:
  - consistency with agent6 image
  - java8 support for latest jboss jar
  - longer support (official support for jessie ends June 2018)

Size is in the same ballpark as jessie:

- latest: 150 MB
- xvello_stretch: 149 MB
- latest-jmx: 214 MB
- xvello_stretch_jmx: 203 MB


### Testing Guidelines
- [x] latest starts with no error
- [x] latest-dogstatsd starts with no error
- [x] latest-jmx starts with no error
- [x] AD works
- [x] JMX AD works on -jmx variant
- [x] Host network metrics are correct
- [x] Deploy on DCOS 1.10
- [x] Deploy on GKE
- [x] Container Live View
- [x] Trace submission

### Agent info


```
====================
Collector (v 5.22.1)
====================

  Status date: 2018-03-02 14:18:39 (3s ago)
  Pid: 30
  Platform: Linux-4.4.0-112-generic-x86_64-with-debian-9.3
  Python Version: 2.7.14, 64bit
  Logs: <stderr>, /var/log/datadog/collector.log

  Clocks
  ======

    NTP offset: 0.0727 s
    System UTC time: 2018-03-02 14:18:43.309019

  Paths
  =====

    conf.d: /etc/dd-agent/conf.d
    checks.d: Not found

  Hostnames
  =========

    socket-hostname: 8b45d3384746
    hostname: ci-xaviervello
    socket-fqdn: 8b45d3384746

  Checks
  ======

    network (1.4.0)
    ---------------
      - instance #0 [OK]
      - Collected 80 metrics, 0 events & 0 service checks

    etcd (1.3.0)
    ------------
      - Collected 0 metrics, 0 events & 0 service checks

    redisdb (1.4.0)
    ---------------
      - instance #0 [OK]
      - instance #1 [OK]
      - instance #2 [OK]
      - Collected 109 metrics, 0 events & 5 service checks
      - Dependencies:
          - redis: 2.10.5

    ntp (1.0.0)
    -----------
      - Collected 0 metrics, 0 events & 0 service checks

    disk (1.1.0)
    ------------
      - instance #0 [OK]
      - Collected 36 metrics, 0 events & 0 service checks

    docker_daemon (1.8.0)
    ---------------------
      - instance #0 [OK]
      - Collected 134 metrics, 0 events & 1 service check

    http_check (1.4.0)
    ------------------
      - instance #0 [WARNING]
          Warning: Using events for service checks is deprecated in favor of monitors and will be removed in future versions of the Datadog Agent.
      - Collected 3 metrics, 0 events & 1 service check

    AD-jmx_0 (5.22.1)
    -----------------
      - instance #AD-jmx_0-172.18.0.7-7199 [OK] collected 13 metrics
      - Collected 13 metrics, 0 events & 0 service checks


  Emitters
  ========

    - http_emitter [OK]
```