### PR TITLE
rhel: disable rhel-7-server-htb-rpms repo

### DIFF
--- a/Dockerfile-rhel
+++ b/Dockerfile-rhel
@@ -41,7 +41,8 @@ COPY rhel/datadog.repo /etc/yum.repos.d/datadog.repo
 COPY probe.sh /probe.sh
 
 # Install the Agent
-RUN yum -y install datadog-agent-${AGENT_VERSION} \
+RUN yum-config-manager --disable rhel-7-server-htb-rpms \
+ && yum -y install datadog-agent-${AGENT_VERSION} \
  && rpm -e --justdb datadog-agent-${AGENT_VERSION} \
  && yum clean all && rm -rf /var/cache/yum \
  && cp /etc/dd-agent/datadog.conf.example /etc/dd-agent/datadog.conf \


### PR DESCRIPTION
### What does this PR do?

Restore the build of the rhel image, that is currently failing because of 

> [91mhttps://cdn.redhat.com/content/htb/rhel/server/7/x86_64/os/repodata/repomd.xml: [Errno 14] HTTPS Error 403 - Forbidden

HTB: https://access.redhat.com/solutions/513153

We don't pull packages from this repo, might as well disable it
