### PR TITLE
[README] Update the Amazon Linux cgroup details 

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ docker run -d --name dd-agent \
   datadog/docker-dd-agent:latest
 ```
 
-If you are running on Amazon Linux (version < 2), use the following instead:
+If you are running on Amazon Linux with version < 2, use the following instead:
 
 ```
 docker run -d --name dd-agent \

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ docker run -d --name dd-agent \
   datadog/docker-dd-agent:latest
 ```
 
-If you are running on Amazon Linux, use the following instead:
+If you are running on Amazon Linux (version < 2), use the following instead:
 
 ```
 docker run -d --name dd-agent \


### PR DESCRIPTION
### What does this PR do?

Update the Amazon Linux cgroup details: for Amazon Linux 2, it's now standard on `/sys/fs/cgroup` instead of different in `/cgroup`.

### Motivation
Support issue