### PR TITLE
Update RHEL image to 5.26

### DIFF
--- a/Dockerfile-rhel
+++ b/Dockerfile-rhel
@@ -3,7 +3,7 @@ MAINTAINER Datadog <package@datadoghq.com>
 
 ENV DOCKER_DD_AGENT=yes \
     DD_LOGS_STDOUT=yes \
-    AGENT_VERSION=5.19.0-1 \
+    AGENT_VERSION=5.26.0-1 \
     DD_ETC_ROOT=/etc/dd-agent \
     PATH="/opt/datadog-agent/embedded/bin:/opt/datadog-agent/bin:${PATH}" \
     PYTHONPATH=/opt/datadog-agent/agent \


### PR DESCRIPTION
Update RHEL image to 5.26

*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*


### What does this PR do?

Update Docker RHEL image to 5.26.x