### PR TITLE
add HISTOGRAM_AGGREGATES to configurable env_variables and config_builder.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ Some configuration parameters can be changed with environment variables:
 * `DD_COLLECT_LABELS_AS_TAGS` Enables the collection of the listed labels as tags. Comma separated string, without spaces unless in quotes. Exemple: `-e DD_COLLECT_LABELS_AS_TAGS='com.docker.label.foo, com.docker.label.bar'` or `-e DD_COLLECT_LABELS_AS_TAGS=com.docker.label.foo,com.docker.label.bar`.
 
 * `MAX_TRACES_PER_SECOND`: Specifies the maximum number of traces per second to sample for APM.  Set to `0` to disable this limit.
+* `DD_HISTOGRAM_PERCENTILES`: histogram percentiles to compute, separated by spaces. The default is "0.95"
+* `DD_HISTOGRAM_AGGREGATES`: histogram aggregates to compute, separated by spaces. The default is "max median avg count"
 
 **Note:** Some of those have alternative names, but with the same impact: it is possible to use `DD_TAGS` instead of `TAGS`, `DD_LOG_LEVEL` instead of `LOG_LEVEL` and `DD_API_KEY` instead of `API_KEY`.
 

--- a/config_builder.py
+++ b/config_builder.py
@@ -69,6 +69,8 @@ class ConfBuilder(object):
         self.set_from_env_mapping('DD_URL', 'dd_url')
         self.set_from_env_mapping('STATSD_METRIC_NAMESPACE', 'statsd_metric_namespace')
         self.set_from_env_mapping('USE_DOGSTATSD', 'use_dogstatsd')
+        # Histogram Aggregates and Histogram Percentile configuration
+        self.set_from_env_mapping('DD_HISTOGRAM_AGGREGATES', 'histogram_aggregates')
         self.set_from_env_mapping('DD_HISTOGRAM_PERCENTILES', 'histogram_percentiles')
         ##### Proxy config #####
         self.set_from_env_mapping('PROXY_HOST', 'proxy_host')


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*


### What does this PR do?

Adds `histogram_aggregates` as a configurable setting via config_builder
Updates README to reflect that these ENV variables are something that can be set on image.

### Motivation

This setting isn't configurable currently for 5.x agents , adding this options matches it to what we provide on agent v6. 

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
