### PR TITLE
[docker][cli] add arguments to allow easy custom builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,14 @@ FROM debian:stretch
 
 MAINTAINER Datadog <package@datadoghq.com>
 
+ARG AGENT_VERSION_ARG=1:5.30.1-1
+ARG AGENT_REPO_ARG="http://apt.datadoghq.com/"
+ARG AGENT_REPO_CHANNEL_ARG=stable
+
 ENV DOCKER_DD_AGENT=yes \
-    AGENT_VERSION=1:5.30.1-1 \
+    AGENT_VERSION=$AGENT_VERSION_ARG \
+    AGENT_REPO=$AGENT_REPO_ARG \
+    AGENT_REPO_CHANNEL=$AGENT_REPO_CHANNEL_ARG \
     DD_ETC_ROOT=/etc/dd-agent \
     PATH="/opt/datadog-agent/embedded/bin:/opt/datadog-agent/bin:${PATH}" \
     PYTHONPATH=/opt/datadog-agent/agent \
@@ -15,7 +21,7 @@ ENV DOCKER_DD_AGENT=yes \
 # Install the Agent
 RUN apt-get update \
  && apt-get install --no-install-recommends -y gnupg dirmngr \
- && echo "deb http://apt.datadoghq.com/ stable main" > /etc/apt/sources.list.d/datadog.list \
+ && echo "deb ${AGENT_REPO} ${AGENT_REPO_CHANNEL} main" > /etc/apt/sources.list.d/datadog.list \
  && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A2923DFF56EDA6E76E55E492D3A80E30382E94DE \
  && apt-get update \
  && apt-get install --no-install-recommends -y datadog-agent="${AGENT_VERSION}" \

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -2,12 +2,14 @@ FROM alpine:3.6
 
 MAINTAINER Datadog <package@datadoghq.com>
 
+ARG AGENT_VERSION_ARG=5.30.1
+
 ENV DD_HOME=/opt/datadog-agent \
     # prevent the agent from being started after install
     DD_START_AGENT=0 \
     DOCKER_DD_AGENT=yes \
     PYCURL_SSL_LIBRARY=openssl \
-    AGENT_VERSION=5.30.1 \
+    AGENT_VERSION=$AGENT_VERSION_ARG \
     DD_ETC_ROOT="/opt/datadog-agent/agent" \
     PATH="/opt/datadog-agent/venv/bin:/opt/datadog-agent/agent/bin:$PATH" \
     PYTHONPATH="/opt/datadog-agent/agent" \

--- a/Dockerfile-dogstatsd
+++ b/Dockerfile-dogstatsd
@@ -2,8 +2,14 @@ FROM debian:stretch
 
 MAINTAINER Datadog <package@datadoghq.com>
 
+ARG AGENT_VERSION_ARG=1:5.30.1-1
+ARG AGENT_REPO_ARG="http://apt.datadoghq.com/"
+ARG AGENT_REPO_CHANNEL_ARG=stable
+
 ENV DOCKER_DD_AGENT=yes \
-    AGENT_VERSION=1:5.30.1-1 \
+    AGENT_VERSION=$AGENT_VERSION_ARG \
+    AGENT_REPO=$AGENT_REPO_ARG \
+    AGENT_REPO_CHANNEL=$AGENT_REPO_CHANNEL_ARG \
     DD_ETC_ROOT=/etc/dd-agent \
     PATH="/opt/datadog-agent/embedded/bin:/opt/datadog-agent/bin:${PATH}" \
     PYTHONPATH=/opt/datadog-agent/agent \
@@ -13,7 +19,7 @@ ENV DOCKER_DD_AGENT=yes \
 # Install the Agent
 RUN apt-get update \
  && apt-get install --no-install-recommends -y gnupg dirmngr \
- && echo "deb http://apt.datadoghq.com/ stable main" > /etc/apt/sources.list.d/datadog.list \
+ && echo "deb ${AGENT_REPO} ${AGENT_REPO_CHANNEL} main" > /etc/apt/sources.list.d/datadog.list \
  && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A2923DFF56EDA6E76E55E492D3A80E30382E94DE \
  && apt-get update \
  && apt-get install --no-install-recommends -y datadog-agent="${AGENT_VERSION}" \

--- a/Dockerfile-dogstatsd-alpine
+++ b/Dockerfile-dogstatsd-alpine
@@ -2,11 +2,13 @@ FROM alpine:3.6
 
 MAINTAINER Datadog <package@datadoghq.com>
 
+ARG AGENT_VERSION_ARG=5.30.1
+
 ENV DD_HOME=/opt/datadog-agent \
     DOCKER_DD_AGENT=yes \
     # prevent the agent from being started after install
     DD_START_AGENT=0 \
-    AGENT_VERSION=5.30.1 \
+    AGENT_VERSION=$AGENT_VERSION_ARG \
     DD_ETC_ROOT="/opt/datadog-agent/agent" \
     PATH="/opt/datadog-agent/venv/bin:/opt/datadog-agent/agent/bin:$PATH" \
     PYTHONPATH=/opt/datadog-agent/agent \

--- a/Dockerfile-jmx
+++ b/Dockerfile-jmx
@@ -26,7 +26,7 @@ RUN apt-get update \
  && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A2923DFF56EDA6E76E55E492D3A80E30382E94DE \
  && apt-get update \
  && apt-get install --no-install-recommends -y datadog-agent="${AGENT_VERSION}" \
-&& apt-get install --no-install-recommends -y openjdk-8-jre-headless \
+ && apt-get install --no-install-recommends -y openjdk-8-jre-headless \
  && apt-get install --no-install-recommends -y ca-certificates \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/Dockerfile-jmx
+++ b/Dockerfile-jmx
@@ -2,8 +2,14 @@ FROM debian:stretch
 
 MAINTAINER Datadog <package@datadoghq.com>
 
+ARG AGENT_VERSION_ARG=1:5.30.1-1
+ARG AGENT_REPO_ARG="http://apt.datadoghq.com/"
+ARG AGENT_REPO_CHANNEL_ARG=stable
+
 ENV DOCKER_DD_AGENT=yes \
-    AGENT_VERSION=1:5.30.1-1 \
+    AGENT_VERSION=$AGENT_VERSION_ARG \
+    AGENT_REPO=$AGENT_REPO_ARG \
+    AGENT_REPO_CHANNEL=$AGENT_REPO_CHANNEL_ARG \
     DD_ETC_ROOT=/etc/dd-agent \
     PATH="/opt/datadog-agent/embedded/bin:/opt/datadog-agent/bin:${PATH}" \
     PYTHONPATH=/opt/datadog-agent/agent \
@@ -16,7 +22,7 @@ ENV DOCKER_DD_AGENT=yes \
 # Install the Agent
 RUN apt-get update \
  && apt-get install --no-install-recommends -y gnupg dirmngr \
- && echo "deb http://apt.datadoghq.com/ stable main" > /etc/apt/sources.list.d/datadog.list \
+ && echo "deb ${AGENT_REPO} ${AGENT_REPO_CHANNEL} main" > /etc/apt/sources.list.d/datadog.list \
  && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A2923DFF56EDA6E76E55E492D3A80E30382E94DE \
  && apt-get update \
  && apt-get install --no-install-recommends -y datadog-agent="${AGENT_VERSION}" \


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*


### What does this PR do?

This PR allows build arguments to enable easily building custom images for our agents by parametrizing repository, channel and agent version. We still keep sane defaults.

### Motivation

Improving our QA automation pipeline for docker.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.
