### PR TITLE
Add INTEGRATIONS_VERSION

### DIFF
--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -10,6 +10,7 @@ ENV DD_HOME=/opt/datadog-agent \
     DOCKER_DD_AGENT=yes \
     PYCURL_SSL_LIBRARY=openssl \
     AGENT_VERSION=$AGENT_VERSION_ARG \
+    INTEGRATIONS_VERSION=$AGENT_VERSION_ARG \
     DD_ETC_ROOT="/opt/datadog-agent/agent" \
     PATH="/opt/datadog-agent/venv/bin:/opt/datadog-agent/agent/bin:$PATH" \
     PYTHONPATH="/opt/datadog-agent/agent" \


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*


### What does this PR do?

Specify INTEGRATIONS_VERSION

### Motivation

pipeline fails without this because we get the version in `config.py` which is `5.31.0` which doesn't exist yet.
