### PR TITLE
[dockerfiles] pin to latest stretch 20200607-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:stretch-20200607-slim
 
 MAINTAINER Datadog <package@datadoghq.com>
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,9 @@ ENV DOCKER_DD_AGENT=yes \
     DD_SUPERVISOR_DELETE_USER=yes \
     DD_CONF_PROCFS_PATH="/host/proc"
 
+# workaround for stretch-slim missing man dirs
+RUN seq 1 8 | xargs -I{} mkdir -p /usr/share/man/man{}
+
 # Install the Agent
 RUN apt-get update \
  && apt-get install --no-install-recommends -y gnupg dirmngr \

--- a/Dockerfile-dogstatsd
+++ b/Dockerfile-dogstatsd
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:stretch-20200607-slim
 
 MAINTAINER Datadog <package@datadoghq.com>
 

--- a/Dockerfile-dogstatsd
+++ b/Dockerfile-dogstatsd
@@ -16,6 +16,9 @@ ENV DOCKER_DD_AGENT=yes \
     DD_CONF_LOG_TO_SYSLOG=no \
     NON_LOCAL_TRAFFIC=yes
 
+# workaround for stretch-slim missing man dirs
+RUN seq 1 8 | xargs -I{} mkdir -p /usr/share/man/man{}
+
 # Install the Agent
 RUN apt-get update \
  && apt-get install --no-install-recommends -y gnupg dirmngr \

--- a/Dockerfile-jmx
+++ b/Dockerfile-jmx
@@ -19,6 +19,9 @@ ENV DOCKER_DD_AGENT=yes \
     DD_SUPERVISOR_DELETE_USER=yes \
     DD_CONF_PROCFS_PATH="/host/proc"
 
+# workaround for stretch-slim missing man dirs
+RUN seq 1 8 | xargs -I{} mkdir -p /usr/share/man/man{}
+
 # Install the Agent
 RUN apt-get update \
  && apt-get install --no-install-recommends -y gnupg dirmngr \

--- a/Dockerfile-jmx
+++ b/Dockerfile-jmx
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:stretch-20200607-slim
 
 MAINTAINER Datadog <package@datadoghq.com>
 


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*


### What does this PR do?

We should pin our images for reproducible builds.

This pins to the latest `stretch` hopefully addressing some of the CVEs in older images. By moving to the `slim` image we will hopefully also reduce the footprint and likelihood of shipping vulnerable code in the image unrelated to the agent itself.

### Motivation

Sanity, security.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Let's run this by the scanners.
