### PR TITLE
[base] moving to buster slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:stretch-20200607-slim
 
 MAINTAINER Datadog <package@datadoghq.com>
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch-20200607-slim
+FROM debian:buster-20200607-slim
 
 MAINTAINER Datadog <package@datadoghq.com>
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,9 @@ ENV DOCKER_DD_AGENT=yes \
     DD_SUPERVISOR_DELETE_USER=yes \
     DD_CONF_PROCFS_PATH="/host/proc"
 
+# workaround for stretch-slim missing man dirs
+RUN seq 1 8 | xargs -I{} mkdir -p /usr/share/man/man{}
+
 # Install the Agent
 RUN apt-get update \
  && apt-get install --no-install-recommends -y gnupg dirmngr \

--- a/Dockerfile-dogstatsd
+++ b/Dockerfile-dogstatsd
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:stretch-20200607-slim
 
 MAINTAINER Datadog <package@datadoghq.com>
 

--- a/Dockerfile-dogstatsd
+++ b/Dockerfile-dogstatsd
@@ -16,6 +16,9 @@ ENV DOCKER_DD_AGENT=yes \
     DD_CONF_LOG_TO_SYSLOG=no \
     NON_LOCAL_TRAFFIC=yes
 
+# workaround for stretch-slim missing man dirs
+RUN seq 1 8 | xargs -I{} mkdir -p /usr/share/man/man{}
+
 # Install the Agent
 RUN apt-get update \
  && apt-get install --no-install-recommends -y gnupg dirmngr \

--- a/Dockerfile-dogstatsd
+++ b/Dockerfile-dogstatsd
@@ -1,4 +1,4 @@
-FROM debian:stretch-20200607-slim
+FROM debian:buster-20200607-slim
 
 MAINTAINER Datadog <package@datadoghq.com>
 

--- a/Dockerfile-jmx
+++ b/Dockerfile-jmx
@@ -19,6 +19,9 @@ ENV DOCKER_DD_AGENT=yes \
     DD_SUPERVISOR_DELETE_USER=yes \
     DD_CONF_PROCFS_PATH="/host/proc"
 
+# workaround for stretch-slim missing man dirs
+RUN seq 1 8 | xargs -I{} mkdir -p /usr/share/man/man{}
+
 # Install the Agent
 RUN apt-get update \
  && apt-get install --no-install-recommends -y gnupg dirmngr \

--- a/Dockerfile-jmx
+++ b/Dockerfile-jmx
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:stretch-20200607-slim
 
 MAINTAINER Datadog <package@datadoghq.com>
 

--- a/Dockerfile-jmx
+++ b/Dockerfile-jmx
@@ -29,7 +29,7 @@ RUN apt-get update \
  && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A2923DFF56EDA6E76E55E492D3A80E30382E94DE \
  && apt-get update \
  && apt-get install --no-install-recommends -y datadog-agent="${AGENT_VERSION}" \
- && apt-get install --no-install-recommends -y openjdk-8-jre-headless \
+ && apt-get install --no-install-recommends -y openjdk-11-jre-headless \
  && apt-get install --no-install-recommends -y ca-certificates \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/Dockerfile-jmx
+++ b/Dockerfile-jmx
@@ -1,4 +1,4 @@
-FROM debian:stretch-20200607-slim
+FROM debian:buster-20200607-slim
 
 MAINTAINER Datadog <package@datadoghq.com>
 


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*


### What does this PR do?

Updates the docker agent base image to use the more current buster slim

### Motivation

More current, secure base image.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
