### PR TITLE
[dockerfile] base: update to buster-20200803-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-20200607-slim
+FROM debian:buster-20200803-slim
 
 MAINTAINER Datadog <package@datadoghq.com>
 

--- a/Dockerfile-dogstatsd
+++ b/Dockerfile-dogstatsd
@@ -1,4 +1,4 @@
-FROM debian:buster-20200607-slim
+FROM debian:buster-20200803-slim
 
 MAINTAINER Datadog <package@datadoghq.com>
 

--- a/Dockerfile-jmx
+++ b/Dockerfile-jmx
@@ -1,4 +1,4 @@
-FROM debian:buster-20200607-slim
+FROM debian:buster-20200803-slim
 
 MAINTAINER Datadog <package@datadoghq.com>
 


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*


### What does this PR do?

Bumps to buster-20200803-slim.

### Motivation

Desirable updates to base images.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.
